### PR TITLE
Fix assignment/assessment identifier mismatch issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode
+.vscode
+
+# for Mac
+.DS_Store

--- a/text2qti/qti.py
+++ b/text2qti/qti.py
@@ -36,7 +36,7 @@ class QTI(object):
                                            dependency_identifier=self.dependency_identifier,
                                            images=self.quiz.images)
         self.assessment_meta = assessment_meta(assessment_identifier=self.assessment_identifier,
-                                               assignment_identifier=self.assessment_identifier,
+                                               assignment_identifier=self.assignment_identifier,
                                                assignment_group_identifier=self.assignment_group_identifier,
                                                title_xml=quiz.title_xml,
                                                description_html_xml=quiz.description_html_xml,
@@ -46,7 +46,7 @@ class QTI(object):
                                                one_question_at_a_time=quiz.one_question_at_a_time_xml,
                                                cant_go_back=quiz.cant_go_back_xml)
         self.assessment = assessment(quiz=quiz,
-                                     assessment_identifier=self.assignment_identifier,
+                                     assessment_identifier=self.assessment_identifier,
                                      title_xml=quiz.title_xml)
 
 


### PR DESCRIPTION
#18 
There is an identifier mismatch problem in the generated assessment_meta.xml, which will lead to an issue that Canvas ignores the quiz description, quiz options, and questions titles. The root cause of the problem is in the `qti.py`, when instantiating the assessment_meta and assessment. Simply change the following lines will fix the issue:

line 39 in qti.py:
From: assignment_identifier=self.assessment_identifier,
To: assignment_identifier=self. assignment_identifier,

line 49 in qti.py:
From: assessment_identifier=self.assignment_identifier,
To: assessment_identifier=self. assessment_identifier,