### PR TITLE
Small fix to avoid doubling of relative path in output filename.

### DIFF
--- a/text2qti/cmdline.py
+++ b/text2qti/cmdline.py
@@ -90,6 +90,6 @@ def main():
     try:
         quiz = Quiz(text, config=config, source_name=file_path.as_posix())
         qti = QTI(quiz)
-        qti.save(file_path.parent / f'{file_path.stem}.zip')
+        qti.save(f'{file_path.stem}.zip')
     finally:
         os.chdir(cwd)

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -676,8 +676,8 @@ class Group(object):
         self.questions.append(question)
 
     def finalize(self):
-        if len(self.questions) <= self.pick:
-            raise Text2qtiError(f'Question group only contains {len(self.questions)} questions, needs at least {self.pick+1}')
+        if len(self.questions) < self.pick:
+            raise Text2qtiError(f'Question group only contains {len(self.questions)} questions, needs at least {self.pick}')
         h = hashlib.blake2b()
         for digest in sorted(q.hash_digest for q in self.questions):
             h.update(digest)

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -231,6 +231,8 @@ class Formula(object):
         }
     
     def __init__(self, formula: str, decimal_places: int):
+        if '**' in formula:
+            raise Text2qtiError(f'Formula contains **, must use ^ for Canvas-compatible formulas.')
         self.formula = formula
         self.decimal_places = decimal_places
         self.delta = 10**(-decimal_places)
@@ -557,6 +559,8 @@ class Question(object):
         vmin = float(parts[1])
         vmax = float(parts[2])
         vdecimals = int(parts[3])
+        if f'[{vname}]' not in self.question_raw:
+            raise Text2qtiError(f'Calculated question defines variable that does not appear in text.')
         self.calculated_varsets.vars.append(CalculatedVar(vname, vmin, vmax, vdecimals))
         
     def append_calculated_answer(self, text: str):

--- a/text2qti/unravel.py
+++ b/text2qti/unravel.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Glenn Horton-Smith
+# All rights reserved.
+#
+# Licensed under the BSD 3-Clause License:
+# http://opensource.org/licenses/BSD-3-Clause
+#
+
+def unravel(i, b):
+    '''
+    Breaks up a flat index i into a list of coordinates
+    of dimension len(b) with sizes given by array b.
+    Equivalent to numpy.unravel_index(), except always returns
+    indexes in 'F' order, and is faster.
+    '''
+    o = [0]*len(b)
+    for ii in range(len(b)):
+       o[ii] = i%b[ii]
+       i //= b[ii]
+    return o


### PR DESCRIPTION
I noticed that if a relative path is used for the input file, the output directory has that relative path doubled. E.g., if the input filename is  ../test.txt, the output is written to ../../test.zip.  This small fix corrects that little problem.