### PR TITLE
Small fix to avoid doubling of relative path in output filename.

### DIFF
--- a/text2qti/cmdline.py
+++ b/text2qti/cmdline.py
@@ -90,6 +90,6 @@ def main():
     try:
         quiz = Quiz(text, config=config, source_name=file_path.as_posix())
         qti = QTI(quiz)
-        qti.save(file_path.parent / f'{file_path.stem}.zip')
+        qti.save(f'{file_path.stem}.zip')
     finally:
         os.chdir(cwd)


### PR DESCRIPTION
This is a fix to issue #28 .