### PR TITLE
Option added for controlling number of attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,8 @@ description.
 * `One question at a time` — Only show one question at a time.
 * `Can't go back` — Don't allow going back to the previous question when in
   `One question at a time` mode.
-
+* `Number of attempts` — Set number of quiz attempts allowed. Setting this
+  overrides the default of 1 attempt. Set to 0 for unlimited attempts.
 
 
 

--- a/text2qti/qti.py
+++ b/text2qti/qti.py
@@ -44,7 +44,8 @@ class QTI(object):
                                                shuffle_answers=quiz.shuffle_answers_xml,
                                                show_correct_answers=quiz.show_correct_answers_xml,
                                                one_question_at_a_time=quiz.one_question_at_a_time_xml,
-                                               cant_go_back=quiz.cant_go_back_xml)
+                                               cant_go_back=quiz.cant_go_back_xml,
+					       allowed_attempts=quiz.allowed_attempts_xml)
         self.assessment = assessment(quiz=quiz,
                                      assessment_identifier=self.assessment_identifier,
                                      title_xml=quiz.title_xml)

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -61,6 +61,7 @@ start_patterns = {
     'quiz_show_correct_answers': r'[Ss]how correct answers:',
     'quiz_one_question_at_a_time': r'[Oo]ne question at a time:',
     'quiz_cant_go_back': r'''[Cc]an't go back:''',
+    'quiz_allowed_attempts': r'[Nn]umber of attempts:',
 }
 # comments are currently handled separately from content
 comment_patterns = {
@@ -74,7 +75,8 @@ no_content = set(['essay', 'upload', 'start_group', 'end_group', 'start_code', '
 single_line = set(['question_points', 'group_pick', 'group_points_per_question',
                    'numerical', 'shortans_correct_choice',
                    'quiz_shuffle_answers', 'quiz_show_correct_answers',
-                   'quiz_one_question_at_a_time', 'quiz_cant_go_back'])
+                   'quiz_one_question_at_a_time', 'quiz_cant_go_back',
+                   'quiz_allowed_attempts'])
 multi_line = set([x for x in start_patterns
                   if x not in no_content and x not in single_line])
 # whether parser needs to check for multi-paragraph content
@@ -557,6 +559,8 @@ class Quiz(object):
         self.one_question_at_a_time_xml = 'false'
         self.cant_go_back_raw = None
         self.cant_go_back_xml = 'false'
+        self.allowed_attempts_raw = None
+        self.allowed_attempts_xml = 1
         self.questions_and_delims: List[Union[Question, GroupStart, GroupEnd, TextRegion]] = []
         self._current_group: Optional[Group] = None
         # The set for detecting duplicate questions uses the XML version of
@@ -737,7 +741,8 @@ class Quiz(object):
 
     def append_quiz_title(self, text: str):
         if any(x is not None for x in (self.shuffle_answers_raw, self.show_correct_answers_raw,
-                                       self.one_question_at_a_time_raw, self.cant_go_back_raw)):
+                                       self.one_question_at_a_time_raw, self.cant_go_back_raw,
+				       self.allowed_attempts_raw)):
             raise Text2qtiError('Must give quiz title before quiz options')
         if self._next_question_attr:
             raise Text2qtiError('Expected question; question title and/or points were set but not used')
@@ -752,7 +757,8 @@ class Quiz(object):
 
     def append_quiz_description(self, text: str):
         if any(x is not None for x in (self.shuffle_answers_raw, self.show_correct_answers_raw,
-                                       self.one_question_at_a_time_raw, self.cant_go_back_raw)):
+                                       self.one_question_at_a_time_raw, self.cant_go_back_raw,
+                                       self.allowed_attempts_raw)):
             raise Text2qtiError('Must give quiz description before quiz options')
         if self._next_question_attr:
             raise Text2qtiError('Expected question; question title and/or points were set but not used')
@@ -812,6 +818,22 @@ class Quiz(object):
             raise Text2qtiError('''Must set "One question at a time" to "true" before setting "Can't go back"''')
         self.cant_go_back_raw = text
         self.cant_go_back_xml = text.lower()
+
+    def append_quiz_allowed_attempts(self, text: int):
+        if self._next_question_attr:
+            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+        if self.questions_and_delims:
+            raise Text2qtiError('Must give quiz options before questions')
+        if self.allowed_attempts_raw is not None:
+            raise Text2qtiError('Quiz option "Number of attempts" has already been set')
+        if int(text) < 0:
+            raise Text2qtiError('Expected option value cannot be less than 0')
+        self.allowed_attempts_raw = text
+        self.allowed_attempts_xml = text
+        #if text not in ('true', 'True', 'false', 'False'):
+        #    raise Text2qtiError('Expected option value "true" or "false"')
+        #self.shuffle_answers_raw = text
+        #self.shuffle_answers_xml = text.lower()
 
     def append_text_title(self, text: str):
         if self._next_question_attr:

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -830,10 +830,6 @@ class Quiz(object):
             raise Text2qtiError('Expected option value cannot be less than 0')
         self.allowed_attempts_raw = text
         self.allowed_attempts_xml = text
-        #if text not in ('true', 'True', 'false', 'False'):
-        #    raise Text2qtiError('Expected option value "true" or "false"')
-        #self.shuffle_answers_raw = text
-        #self.shuffle_answers_xml = text.lower()
 
     def append_text_title(self, text: str):
         if self._next_question_attr:

--- a/text2qti/xml_assessment_meta.py
+++ b/text2qti/xml_assessment_meta.py
@@ -28,7 +28,7 @@ TEMPLATE = '''\
   <show_correct_answers>{show_correct_answers}</show_correct_answers>
   <anonymous_submissions>false</anonymous_submissions>
   <could_be_locked>false</could_be_locked>
-  <allowed_attempts>1</allowed_attempts>
+  <allowed_attempts>{allowed_attempts}</allowed_attempts>
   <one_question_at_a_time>{one_question_at_a_time}</one_question_at_a_time>
   <cant_go_back>{cant_go_back}</cant_go_back>
   <available>false</available>
@@ -93,7 +93,8 @@ def assessment_meta(*,
                     shuffle_answers: str,
                     show_correct_answers: str,
                     one_question_at_a_time: str,
-                    cant_go_back: str) -> str:
+                    cant_go_back: str,
+		    allowed_attempts: str) -> str:
     '''
     Generate `assessment_meta.xml`.
     '''
@@ -107,4 +108,5 @@ def assessment_meta(*,
                            show_correct_answers=show_correct_answers,
                            hide_results='always' if show_correct_answers == 'false' else '',
                            one_question_at_a_time=one_question_at_a_time,
-                           cant_go_back=cant_go_back)
+                           cant_go_back=cant_go_back,
+			   allowed_attempts=allowed_attempts)


### PR DESCRIPTION
Note: Please bear with me, as this is my first experience with a real-world pull request. Let me know if there are any questions or you have any feedback.

Motivation: The current commit does not allow users to set the number of quiz attempts allowed and the default settings are for only 1 attempt.

Overview of changes: 
* I used the existing code that facilitated the question shuffling feature to guide changes
* QTI standard allows an arbitrary non-negative number of attempts to be specified and user can use `0` to set unlimited attempts
* Most changes were straightforward and should be fine
* You may want to double-check my handling of variable types in function `append_quiz_allowed_attempts` in `text2qti/quiz.py`. I know basic Python, so was not sure if how I handled this follows best practices.
* The new feature is briefly documented in changes to `README.md`
* I did some very basic testing by eliminating the option line in `quiz.md` test file, which set attempts=1 in default manner. Added option line to `quiz.md` test file set to 0, 1, 2, 5, and 100 and uploaded to Canvas to confirm unlimited, 1, 2, 5, and 100 allowed attempts, respectively.