### PR TITLE
Added support for base64 images

### DIFF
--- a/text2qti/cmdline.py
+++ b/text2qti/cmdline.py
@@ -52,6 +52,8 @@ def main():
                                  'Consider creating solutions and QTI together, or setting a seed for the random number generator so it is reproducible.')
     parser.add_argument('file',
                         help='File to convert from text to QTI')
+    parser.add_argument('--images-base64', action='store_const', const=True,
+                        help='Save images as base64-encoded data URIs in the HTML file')
     args = parser.parse_args()
 
     config = Config()
@@ -90,6 +92,9 @@ def main():
         config['run_code_blocks'] = args.run_code_blocks
     if args.pandoc_mathml is not None:
         config['pandoc_mathml'] = args.pandoc_mathml
+
+    if args.images_base64 is not None:
+        config['images_base64'] = args.images_base64
 
     file_path = pathlib.Path(args.file).expanduser()
     file_path_abs = file_path.absolute()

--- a/text2qti/config.py
+++ b/text2qti/config.py
@@ -31,11 +31,13 @@ class Config(dict):
     _defaults = {
         'pandoc_mathml': False,
         'run_code_blocks': False,
+        'images_base64': False,
     }
     _key_check = {
         'latex_render_url': lambda x: isinstance(x, str),
         'pandoc_mathml': lambda x: isinstance(x, bool),
         'run_code_blocks': lambda x: isinstance(x, bool),
+        'images_base64': lambda x: isinstance(x, bool),
     }
     _config_path = pathlib.Path('~/.text2qti.bespon').expanduser()
 


### PR DESCRIPTION
This partly closes #55.

# What it does
This adds support to render images as base64 data instead of a URL in the XML file. It implements a `--images-base64` command-line toggle defaulting to `False`. This would produce code like `<img src="data:image/jpeg;base64,/9j/<base64 data>"/>` instead of `<img src="%24IMS-CC-FILEBASE%24/images/trex.jpeg"/>`.

# Lack of base64 image support in LMSes
After thorough evaluation, it does not appear that either Canvas LMS or D2L's BrightSpace, which is my prime target platform, support base64 images well. In more details:
- Canvas LMS does not appear to provide any support whatsoever for base64 images, be it in manual editing or in importing quiz data;
- BrightSpace does support base64 image data in manual editing, although it creates a file and links to it upon save. It does not, however, provide the same service when importing a quiz ZIP file. This would have been sufficient for my use case.

# Potential uses
As is it, I fail to see practical value for my own use case and for Canvas LMS users in this very pull request. However, it may be used in another LMS platform with better support for base64 images. It may also be used as a base for improvements or further investigation by interested parties.

# To do
The mime-type is hard-coded to `jpeg` in this PR, as I did not see real interest in going further for the aforementioned reasons. To make it usable, one would need to detect the images' mime-types, using the [filetype](https://pypi.org/project/filetype/) Python package for instance.

One could also use [PIL to convert image files to base64 directly](https://developpaper.com/example-of-conversion-between-python-pil-cv2-base64/), and then be able to properly handle resizing at the image data level (not the CSS level) and other neat features, but that would add quite a large dependency.