### PR TITLE
New questions types

### DIFF
--- a/text2qti/export.py
+++ b/text2qti/export.py
@@ -293,6 +293,8 @@ def question_to_markdown(question: Question, *,
     elif question.type == 'file_upload_question':
         if not solutions:
             quiz_md.append(indent(_templates['file_upload_placeholder'], 4))
+    elif question.type =='matching_question':
+        pass
     else:
         raise ValueError
 

--- a/text2qti/qti.py
+++ b/text2qti/qti.py
@@ -51,6 +51,7 @@ class QTI(object):
             show_correct_answers=quiz.show_correct_answers_xml,
             one_question_at_a_time=quiz.one_question_at_a_time_xml,
             cant_go_back=quiz.cant_go_back_xml,
+            allowed_attempts=quiz.allowed_attempts_xml,
         )
         self.assessment = assessment(
             quiz=quiz, assessment_identifier=self.assessment_identifier, title_xml=quiz.title_xml

--- a/text2qti/qti.py
+++ b/text2qti/qti.py
@@ -47,6 +47,7 @@ class QTI(object):
             description_html_xml=quiz.description_html_xml,
             points_possible=quiz.points_possible,
             shuffle_answers=quiz.shuffle_answers_xml,
+            shuffle_questions=quiz.shuffle_questions_xml,
             show_correct_answers=quiz.show_correct_answers_xml,
             one_question_at_a_time=quiz.one_question_at_a_time_xml,
             cant_go_back=quiz.cant_go_back_xml,

--- a/text2qti/qti.py
+++ b/text2qti/qti.py
@@ -10,61 +10,64 @@
 
 import io
 import pathlib
-from typing import Union, BinaryIO
 import zipfile
+from typing import BinaryIO, Union
+
 from .quiz import Quiz
-from .xml_imsmanifest import imsmanifest
-from .xml_assessment_meta import assessment_meta
 from .xml_assessment import assessment
+from .xml_assessment_meta import assessment_meta
+from .xml_imsmanifest import imsmanifest
 
 
 class QTI(object):
-    '''
+    """
     Create QTI from a Quiz object.
-    '''
+    """
+
     def __init__(self, quiz: Quiz):
         self.quiz = quiz
-        id_base = 'text2qti'
-        self.manifest_identifier = f'{id_base}_manifest_{quiz.id}'
-        self.assessment_identifier = f'{id_base}_assessment_{quiz.id}'
-        self.dependency_identifier = f'{id_base}_dependency_{quiz.id}'
-        self.assignment_identifier = f'{id_base}_assignment_{quiz.id}'
-        self.assignment_group_identifier = f'{id_base}_assignment-group_{quiz.id}'
+        id_base = "text2qti"
+        self.manifest_identifier = f"{id_base}_manifest_{quiz.id}"
+        self.assessment_identifier = f"{id_base}_assessment_{quiz.id}"
+        self.dependency_identifier = f"{id_base}_dependency_{quiz.id}"
+        self.assignment_identifier = f"{id_base}_assignment_{quiz.id}"
+        self.assignment_group_identifier = f"{id_base}_assignment-group_{quiz.id}"
 
-        self.imsmanifest_xml = imsmanifest(manifest_identifier=self.manifest_identifier,
-                                           assessment_identifier=self.assessment_identifier,
-                                           dependency_identifier=self.dependency_identifier,
-                                           images=self.quiz.images)
-        self.assessment_meta = assessment_meta(assessment_identifier=self.assessment_identifier,
-                                               assignment_identifier=self.assignment_identifier,
-                                               assignment_group_identifier=self.assignment_group_identifier,
-                                               title_xml=quiz.title_xml,
-                                               description_html_xml=quiz.description_html_xml,
-                                               points_possible=quiz.points_possible,
-                                               shuffle_answers=quiz.shuffle_answers_xml,
-                                               show_correct_answers=quiz.show_correct_answers_xml,
-                                               one_question_at_a_time=quiz.one_question_at_a_time_xml,
-                                               cant_go_back=quiz.cant_go_back_xml)
-        self.assessment = assessment(quiz=quiz,
-                                     assessment_identifier=self.assessment_identifier,
-                                     title_xml=quiz.title_xml)
-
+        self.imsmanifest_xml = imsmanifest(
+            manifest_identifier=self.manifest_identifier,
+            assessment_identifier=self.assessment_identifier,
+            dependency_identifier=self.dependency_identifier,
+            images=self.quiz.images,
+        )
+        self.assessment_meta = assessment_meta(
+            assessment_identifier=self.assessment_identifier,
+            assignment_identifier=self.assignment_identifier,
+            assignment_group_identifier=self.assignment_group_identifier,
+            title_xml=quiz.title_xml,
+            description_html_xml=quiz.description_html_xml,
+            points_possible=quiz.points_possible,
+            shuffle_answers=quiz.shuffle_answers_xml,
+            show_correct_answers=quiz.show_correct_answers_xml,
+            one_question_at_a_time=quiz.one_question_at_a_time_xml,
+            cant_go_back=quiz.cant_go_back_xml,
+        )
+        self.assessment = assessment(
+            quiz=quiz, assessment_identifier=self.assessment_identifier, title_xml=quiz.title_xml
+        )
 
     def write(self, bytes_stream: BinaryIO):
-        with zipfile.ZipFile(bytes_stream, 'w', compression=zipfile.ZIP_DEFLATED) as zf:
-            zf.writestr('imsmanifest.xml', self.imsmanifest_xml)
-            zf.writestr(zipfile.ZipInfo('non_cc_assessments/'), b'')
-            zf.writestr(f'{self.assessment_identifier}/assessment_meta.xml', self.assessment_meta)
-            zf.writestr(f'{self.assessment_identifier}/{self.assessment_identifier}.xml', self.assessment)
+        with zipfile.ZipFile(bytes_stream, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("imsmanifest.xml", self.imsmanifest_xml)
+            zf.writestr(zipfile.ZipInfo("non_cc_assessments/"), b"")
+            zf.writestr(f"{self.assessment_identifier}/assessment_meta.xml", self.assessment_meta)
+            zf.writestr(f"{self.assessment_identifier}/{self.assessment_identifier}.xml", self.assessment)
             for image in self.quiz.images.values():
                 zf.writestr(image.qti_zip_path, image.data)
-
 
     def zip_bytes(self) -> bytes:
         stream = io.BytesIO()
         self.write(stream)
         return stream.getvalue()
-
 
     def save(self, qti_path: Union[str, pathlib.Path]):
         if isinstance(qti_path, str):

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -62,6 +62,7 @@ start_patterns = {
     "start_code": r"```+\s*\S.*",
     "end_code": r"```+",
     "quiz_shuffle_answers": r"[Ss]huffle answers:",
+    "quiz_shuffle_questions": r"[Ss]huffle questions:",
     "quiz_show_correct_answers": r"[Ss]how correct answers:",
     "quiz_one_question_at_a_time": r"[Oo]ne question at a time:",
     "quiz_cant_go_back": r"""[Cc]an't go back:""",
@@ -87,6 +88,7 @@ single_line = set(
         "numerical",
         "shortans_correct_choice",
         "quiz_shuffle_answers",
+        "quiz_shuffle_questions",
         "quiz_show_correct_answers",
         "quiz_one_question_at_a_time",
         "quiz_cant_go_back",
@@ -673,6 +675,8 @@ class Quiz(object):
         self.description_html_xml = ""
         self.shuffle_answers_raw = None
         self.shuffle_answers_xml = "false"
+        self.shuffle_questions_raw: str | None = None
+        self.shuffle_questions_xml = "false"
         self.show_correct_answers_raw = None
         self.show_correct_answers_xml = "true"
         self.one_question_at_a_time_raw = None
@@ -984,6 +988,18 @@ class Quiz(object):
             raise Text2qtiError('Expected option value "true" or "false"')
         self.shuffle_answers_raw = text
         self.shuffle_answers_xml = text.lower()
+
+    def append_quiz_shuffle_questions(self, text: str):
+        if self._next_question_attr:
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
+        if self.questions_and_delims:
+            raise Text2qtiError("Must give quiz options before questions")
+        if self.shuffle_questions_raw is not None:
+            raise Text2qtiError('Quiz option "Shuffle answers" has already been set')
+        if text not in ("true", "True", "false", "False"):
+            raise Text2qtiError('Expected option value "true" or "false"')
+        self.shuffle_questions_raw = text
+        self.shuffle_questions_xml = text.lower()
 
     def append_quiz_show_correct_answers(self, text: str):
         if self._next_question_attr:

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -65,6 +65,7 @@ start_patterns = {
     "quiz_shuffle_questions": r"[Ss]huffle questions:",
     "quiz_show_correct_answers": r"[Ss]how correct answers:",
     "quiz_one_question_at_a_time": r"[Oo]ne question at a time:",
+    "quiz_allowed_attempts": r"[Aa]llowed attempts:",
     "quiz_cant_go_back": r"""[Cc]an't go back:""",
     "quiz_feedback_is_solution": r"[Ff]eedback is solution:",
     "quiz_solutions_sample_groups": r"[Ss]olutions sample groups:",
@@ -90,6 +91,7 @@ single_line = set(
         "quiz_shuffle_answers",
         "quiz_shuffle_questions",
         "quiz_show_correct_answers",
+        "quiz_allowed_attempts",
         "quiz_one_question_at_a_time",
         "quiz_cant_go_back",
         "quiz_feedback_is_solution",
@@ -681,6 +683,8 @@ class Quiz(object):
         self.show_correct_answers_xml = "true"
         self.one_question_at_a_time_raw = None
         self.one_question_at_a_time_xml = "false"
+        self.allowed_attempts_raw: str | None = None
+        self.allowed_attempts_xml: str = "1"
         self.cant_go_back_raw = None
         self.cant_go_back_xml = "false"
         self.feedback_is_solution: Optional[bool] = None
@@ -1024,6 +1028,19 @@ class Quiz(object):
             raise Text2qtiError('Expected option value "true" or "false"')
         self.one_question_at_a_time_raw = text
         self.one_question_at_a_time_xml = text.lower()
+
+    def append_quiz_allowed_attempts(self, text: str):
+        if self._next_question_attr:
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
+        if self.questions_and_delims:
+            raise Text2qtiError("Must give quiz options before questions")
+        if self.allowed_attempts_raw is not None:
+            raise Text2qtiError('Quiz option "Shuffle answers" has already been set')
+        if int(text) == -1 or int(text) > 0:
+            self.allowed_attempts_raw = text
+            self.allowed_attempts_xml = text.lower()
+        else:
+            raise Text2qtiError("Expected option value -1 or 1.")
 
     def append_quiz_cant_go_back(self, text: str):
         if self._next_question_attr:

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -50,6 +50,7 @@ start_patterns = {
     "numerical": r"=",
     "question_title": r"[Tt]itle:",
     "question_points": r"[Pp]oints:",
+    "question_calculator_type": r"[Cc]alculator type:",
     "text_title": r"[Tt]ext [Tt]itle:",
     "text": r"[Tt]ext:",
     "quiz_title": r"[Qq]uiz [Tt]itle:",
@@ -227,7 +228,16 @@ class Question(object):
     various types.
     """
 
-    def __init__(self, text: str, *, quiz: "Quiz", title: Optional[str], points: Optional[str], md: Markdown):
+    def __init__(
+        self,
+        text: str,
+        *,
+        quiz: "Quiz",
+        title: Optional[str],
+        points: Optional[str],
+        calculator_type: Optional[str],
+        md: Markdown,
+    ):
         # Question type is set once it is known.  For true/false or multiple
         # choice, this is done during .finalize(), once all choices are
         # available.  For essay, this is done as soon as essay response is
@@ -254,6 +264,12 @@ class Question(object):
         self.numerical_exact_html_xml: Optional[str] = None
         self.numerical_max: Optional[Union[int, float]] = None
         self.numerical_max_html_xml: Optional[str] = None
+        if calculator_type is None:
+            self.calculator_type: str = "none"
+        elif calculator_type in ["basic", "scientific"]:
+            self.calculator_type = calculator_type
+        else:
+            raise ValueError(f'Invalid calculator type "{calculator_type}"; should be "basic" or "scientific"')
         self.correct_choices = 0
         if points is None:
             self.points_possible_raw: Optional[str] = None
@@ -1137,6 +1153,7 @@ class Quiz(object):
             quiz=self,
             title=self._next_question_attr.get("title"),
             points=self._next_question_attr.get("points"),
+            calculator_type=self._next_question_attr.get("calculator_type"),
             md=self.md,
         )
         self._next_question_attr = {}
@@ -1158,6 +1175,11 @@ class Quiz(object):
         if "points" in self._next_question_attr:
             raise Text2qtiError("Points for next question has already been set")
         self._next_question_attr["points"] = text
+
+    def append_question_calculator_type(self, text: str):
+        if "calculator_type" in self._next_question_attr:
+            raise Text2qtiError("Calculator type for next question has already been set")
+        self._next_question_attr["calculator_type"] = text
 
     def append_feedback(self, text: str):
         if self._next_question_attr:

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -280,7 +280,7 @@ class Question(object):
                 points_num = float(points)
             except ValueError:
                 raise Text2qtiError(f'Invalid points value "{points}"; need positive integer or half-integer')
-            if points_num <= 0:
+            if points_num < 0:
                 raise Text2qtiError(f'Invalid points value "{points}"; need positive integer or half-integer')
             if points_num.is_integer():
                 points_num = int(points)

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -826,15 +826,20 @@ class Quiz(object):
 
             points_possible = 0
             digests = []
+            in_group = False
             for x in self.questions_and_delims:
                 if isinstance(x, Question):
-                    points_possible += x.points_possible
-                    digests.append(x.hash_digest)
+                    if not in_group:
+                        points_possible += x.points_possible
+                        digests.append(x.hash_digest)
+                    else:
+                        pass
                 elif isinstance(x, GroupStart):
+                    in_group = True
                     points_possible += x.group.points_per_question * x.group.pick
                     digests.append(x.group.hash_digest)
                 elif isinstance(x, GroupEnd):
-                    pass
+                    in_group = False
                 elif isinstance(x, TextRegion):
                     pass
                 else:

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -40,6 +40,7 @@ start_patterns = {
     'multans_correct_choice': r'\[\*\]',
     'multans_incorrect_choice': r'\[ ?\]',
     'shortans_correct_choice': r'\*',
+    'matching_choice': r'>',
     'feedback': r'\.\.\.',
     'correct_feedback': r'\+',
     'incorrect_feedback': r'\-',
@@ -336,6 +337,16 @@ class Question(object):
         elif self.type != 'multiple_answers_question':
             raise Text2qtiError(f'Question type "{self.type}" does not support multiple answers')
         choice = Choice(text, correct=False, question_hash_digest=self.hash_digest, md=self.md)
+        if choice.choice_html_xml in self._choice_set:
+            raise Text2qtiError('Duplicate choice for question')
+        self._choice_set.add(choice.choice_html_xml)
+        self.choices.append(choice)
+
+    def append_matching_choice(self, text: str):
+        if self.type is None:
+            self.type = 'matching_question'
+        choice = Choice(text, correct=False, question_hash_digest=self.hash_digest, md=self.md)
+
         if choice.choice_html_xml in self._choice_set:
             raise Text2qtiError('Duplicate choice for question')
         self._choice_set.add(choice.choice_html_xml)
@@ -1085,6 +1096,16 @@ class Quiz(object):
         if not isinstance(last_question_or_delim, Question):
             raise Text2qtiError('Cannot have a choice without a question')
         last_question_or_delim.append_multans_incorrect_choice(text)
+
+    def append_matching_choice(self, text: str):
+        if self._next_question_attr:
+            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+        if not self.questions_and_delims:
+            raise Text2qtiError('Cannot have a choice without a question')
+        last_question_or_delim = self.questions_and_delims[-1]
+        if not isinstance(last_question_or_delim, Question):
+            raise Text2qtiError('Cannot have a choice without a question')
+        last_question_or_delim.append_matching_choice(text)
 
     def append_essay(self, text: str):
         if self._next_question_attr:

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -8,11 +8,10 @@
 #
 
 
-'''
+"""
 Parse text into a Quiz object that contains a list of Question objects, each
 of which contains a list of Choice objects.
-'''
-
+"""
 
 import hashlib
 import io
@@ -25,139 +24,158 @@ import shutil
 import subprocess
 import tempfile
 from typing import Dict, List, Optional, Set, Union
+
 from .config import Config
 from .err import Text2qtiError
 from .markdown import Image, Markdown
 
-
-
-
 # regex patterns for parsing quiz content
 start_patterns = {
-    'question': r'\d+\.',
-    'mctf_correct_choice': r'\*[a-zA-Z]\)',
-    'mctf_incorrect_choice': r'[a-zA-Z]\)',
-    'multans_correct_choice': r'\[\*\]',
-    'multans_incorrect_choice': r'\[ ?\]',
-    'shortans_correct_choice': r'\*',
-    'matching_choice': r'>',
-    'feedback': r'\.\.\.',
-    'correct_feedback': r'\+',
-    'incorrect_feedback': r'\-',
-    'solution': r'!',
-    'essay': r'___+',
-    'upload': r'\^\^\^+',
-    'numerical': r'=',
-    'question_title': r'[Tt]itle:',
-    'question_points': r'[Pp]oints:',
-    'text_title': r'[Tt]ext [Tt]itle:',
-    'text': r'[Tt]ext:',
-    'quiz_title': r'[Qq]uiz [Tt]itle:',
-    'quiz_description': r'[Qq]uiz description:',
-    'start_group': r'GROUP',
-    'end_group': r'END_GROUP',
-    'group_pick': r'[Pp]ick:',
-    'group_solutions_pick': r'[Ss]olutions pick:',
-    'group_points_per_question': r'[Pp]oints per question:',
-    'start_code': r'```+\s*\S.*',
-    'end_code': r'```+',
-    'quiz_shuffle_answers': r'[Ss]huffle answers:',
-    'quiz_show_correct_answers': r'[Ss]how correct answers:',
-    'quiz_one_question_at_a_time': r'[Oo]ne question at a time:',
-    'quiz_cant_go_back': r'''[Cc]an't go back:''',
-    'quiz_feedback_is_solution': r'[Ff]eedback is solution:',
-    'quiz_solutions_sample_groups': r'[Ss]olutions sample groups:',
-    'quiz_solutions_randomize_groups': r'[Ss]olutions randomize groups:',
+    "question": r"\d+\.",
+    "mctf_correct_choice": r"\*[a-zA-Z]\)",
+    "mctf_incorrect_choice": r"[a-zA-Z]\)",
+    "multans_correct_choice": r"\[\*\]",
+    "multans_incorrect_choice": r"\[ ?\]",
+    "shortans_correct_choice": r"\*",
+    "matching_choice": r">",
+    "feedback": r"\.\.\.",
+    "correct_feedback": r"\+",
+    "incorrect_feedback": r"\-",
+    "solution": r"!",
+    "essay": r"___+",
+    "upload": r"\^\^\^+",
+    "numerical": r"=",
+    "question_title": r"[Tt]itle:",
+    "question_points": r"[Pp]oints:",
+    "text_title": r"[Tt]ext [Tt]itle:",
+    "text": r"[Tt]ext:",
+    "quiz_title": r"[Qq]uiz [Tt]itle:",
+    "quiz_description": r"[Qq]uiz description:",
+    "start_group": r"GROUP",
+    "end_group": r"END_GROUP",
+    "group_pick": r"[Pp]ick:",
+    "group_solutions_pick": r"[Ss]olutions pick:",
+    "group_points_per_question": r"[Pp]oints per question:",
+    "start_code": r"```+\s*\S.*",
+    "end_code": r"```+",
+    "quiz_shuffle_answers": r"[Ss]huffle answers:",
+    "quiz_show_correct_answers": r"[Ss]how correct answers:",
+    "quiz_one_question_at_a_time": r"[Oo]ne question at a time:",
+    "quiz_cant_go_back": r"""[Cc]an't go back:""",
+    "quiz_feedback_is_solution": r"[Ff]eedback is solution:",
+    "quiz_solutions_sample_groups": r"[Ss]olutions sample groups:",
+    "quiz_solutions_randomize_groups": r"[Ss]olutions randomize groups:",
 }
 # comments are currently handled separately from content
 comment_patterns = {
-    'start_multiline_comment': r'COMMENT',
-    'end_multiline_comment': r'END_COMMENT',
-    'line_comment': r'%',
+    "start_multiline_comment": r"COMMENT",
+    "end_multiline_comment": r"END_COMMENT",
+    "line_comment": r"%",
 }
 # whether regex needs to check after pattern for content on the same line
-no_content = set(['essay', 'upload', 'start_group', 'end_group', 'start_code', 'end_code'])
+no_content = set(["essay", "upload", "start_group", "end_group", "start_code", "end_code"])
 # whether parser needs to check for multi-line content
-single_line = set(['question_points', 'group_pick', 'group_solutions_pick', 'group_points_per_question',
-                   'numerical', 'shortans_correct_choice',
-                   'quiz_shuffle_answers', 'quiz_show_correct_answers',
-                   'quiz_one_question_at_a_time', 'quiz_cant_go_back',
-                   'quiz_feedback_is_solution', 'quiz_solutions_sample_groups', 'quiz_solutions_randomize_groups'])
-multi_line = set([x for x in start_patterns
-                  if x not in no_content and x not in single_line])
+single_line = set(
+    [
+        "question_points",
+        "group_pick",
+        "group_solutions_pick",
+        "group_points_per_question",
+        "numerical",
+        "shortans_correct_choice",
+        "quiz_shuffle_answers",
+        "quiz_show_correct_answers",
+        "quiz_one_question_at_a_time",
+        "quiz_cant_go_back",
+        "quiz_feedback_is_solution",
+        "quiz_solutions_sample_groups",
+        "quiz_solutions_randomize_groups",
+    ]
+)
+multi_line = set([x for x in start_patterns if x not in no_content and x not in single_line])
 # whether parser needs to check for multi-paragraph content
-multi_para = set([x for x in multi_line if 'title' not in x])
-start_re = re.compile('|'.join(r'(?P<{0}>{1}[ \t]+(?=\S))'.format(name, pattern)
-                               if name not in no_content else
-                               r'(?P<{0}>{1}\s*)$'.format(name, pattern)
-                               for name, pattern in start_patterns.items()))
-start_missing_content_re = re.compile('|'.join(r'(?P<{0}>{1}[ \t]*$)'.format(name, pattern)
-                                               for name, pattern in start_patterns.items()
-                                               if name not in no_content))
-start_missing_whitespace_re = re.compile('|'.join(r'(?P<{0}>{1}(?=\S))'.format(name, pattern)
-                                                  for name, pattern in start_patterns.items()
-                                                  if name not in no_content))
-start_code_supported_info_re = re.compile(r'\{\s*'
-                                          r'\.(?P<lang>[a-zA-Z](?:[a-zA-Z0-9]+|[\._\-]+[a-zA-Z0-9]+)*)'
-                                          r'\s+'
-                                          r'\.run'
-                                          r'(?:\s+executable=(?P<executable>[~\w/\.\-]+|"[^\\\"\']+"))?'
-                                          r'\s*\}$')
-int_re = re.compile('(?:0|[+-]?[1-9](?:[0-9]+|_[0-9]+)*)$')
-
-
+multi_para = set([x for x in multi_line if "title" not in x])
+start_re = re.compile(
+    "|".join(
+        r"(?P<{0}>{1}[ \t]+(?=\S))".format(name, pattern)
+        if name not in no_content
+        else r"(?P<{0}>{1}\s*)$".format(name, pattern)
+        for name, pattern in start_patterns.items()
+    )
+)
+start_missing_content_re = re.compile(
+    "|".join(
+        r"(?P<{0}>{1}[ \t]*$)".format(name, pattern)
+        for name, pattern in start_patterns.items()
+        if name not in no_content
+    )
+)
+start_missing_whitespace_re = re.compile(
+    "|".join(
+        r"(?P<{0}>{1}(?=\S))".format(name, pattern)
+        for name, pattern in start_patterns.items()
+        if name not in no_content
+    )
+)
+start_code_supported_info_re = re.compile(
+    r"\{\s*"
+    r"\.(?P<lang>[a-zA-Z](?:[a-zA-Z0-9]+|[\._\-]+[a-zA-Z0-9]+)*)"
+    r"\s+"
+    r"\.run"
+    r'(?:\s+executable=(?P<executable>[~\w/\.\-]+|"[^\\\"\']+"))?'
+    r"\s*\}$"
+)
+int_re = re.compile("(?:0|[+-]?[1-9](?:[0-9]+|_[0-9]+)*)$")
 
 
 class TextRegion(object):
-    '''
+    """
     A text region between questions.
-    '''
+    """
+
     def __init__(self, *, index: int, md: Markdown):
         self.title_raw: Optional[str] = None
-        self.title_xml = ''
+        self.title_xml = ""
         self.text_raw: Optional[str] = None
-        self.text_html_xml = ''
+        self.text_html_xml = ""
         self.md = md
         self._index = index
 
     def _set_id(self):
         h = hashlib.blake2b()
-        h.update(f'{self._index}'.encode('utf8'))
+        h.update(f"{self._index}".encode("utf8"))
         h.update(h.digest())
-        h.update(self.title_xml.encode('utf8'))
+        h.update(self.title_xml.encode("utf8"))
         h.update(h.digest())
-        h.update(self.text_html_xml.encode('utf8'))
+        h.update(self.text_html_xml.encode("utf8"))
         self.id = h.hexdigest()[:64]
 
     def set_title(self, text: str):
         if self.title_raw is not None:
-            raise Text2qtiError('Text title has already been set')
+            raise Text2qtiError("Text title has already been set")
         if self.text_raw is not None:
-            raise Text2qtiError('Must set text title before text itself')
+            raise Text2qtiError("Must set text title before text itself")
         self.title_raw = text
         self.title_xml = self.md.xml_escape(text)
         self._set_id()
 
     def set_text(self, text: str):
         if self.text_raw is not None:
-            raise Text2qtiError('Text has already been set')
+            raise Text2qtiError("Text has already been set")
         self.text_raw = text
         self.text_html_xml = self.md.md_to_html_xml(text)
         self._set_id()
 
 
-
-
 class Choice(object):
-    '''
+    """
     A choice for a question plus optional feedback.
 
     The id is based on a hash of both the question and the choice itself.
     The presence of feedback does not affect the id.
-    '''
-    def __init__(self, text: str, *,
-                 correct: bool, shortans: bool=False,
-                 question_hash_digest: bytes, md: Markdown):
+    """
+
+    def __init__(self, text: str, *, correct: bool, shortans: bool = False, question_hash_digest: bytes, md: Markdown):
         self.choice_raw = text
         if shortans:
             self.choice_xml = md.xml_escape(text)
@@ -170,35 +188,38 @@ class Choice(object):
         # ID is based on hash of choice XML as well as question XML.  This
         # gives different IDs for identical choices in different questions.
         if shortans:
-            self.id = hashlib.blake2b(self.choice_xml.encode('utf8'), key=question_hash_digest).hexdigest()[:64]
+            self.id = hashlib.blake2b(self.choice_xml.encode("utf8"), key=question_hash_digest).hexdigest()[:64]
         else:
-            self.id = hashlib.blake2b(self.choice_html_xml.encode('utf8'), key=question_hash_digest).hexdigest()[:64]
+            self.id = hashlib.blake2b(self.choice_html_xml.encode("utf8"), key=question_hash_digest).hexdigest()[:64]
         self.md = md
 
     def append_feedback(self, text: str):
         if self.shortans:
-            raise Text2qtiError('Feedback cannot be specified for individual short answer responses, only for the question')
+            raise Text2qtiError(
+                "Feedback cannot be specified for individual short answer responses, only for the question"
+            )
         if self.feedback_raw is not None:
-            raise Text2qtiError('Feedback can only be specified once')
+            raise Text2qtiError("Feedback can only be specified once")
         self.feedback_raw = text
         self.feedback_html_xml = self.md.md_to_html_xml(text)
 
 
 class Question(object):
-    '''
+    """
     A question, along with a list of possible choices and optional feedback of
     various types.
-    '''
-    def __init__(self, text: str, *, quiz: 'Quiz', title: Optional[str], points: Optional[str], md: Markdown):
+    """
+
+    def __init__(self, text: str, *, quiz: "Quiz", title: Optional[str], points: Optional[str], md: Markdown):
         # Question type is set once it is known.  For true/false or multiple
         # choice, this is done during .finalize(), once all choices are
         # available.  For essay, this is done as soon as essay response is
         # specified.
         self.type: Optional[str] = None
-        self.quiz: 'Quiz' = quiz
+        self.quiz: "Quiz" = quiz
         if title is None:
             self.title_raw: Optional[str] = None
-            self.title_xml = 'Question'
+            self.title_xml = "Question"
         else:
             self.title_raw: Optional[str] = title
             self.title_xml = md.xml_escape(title)
@@ -230,7 +251,7 @@ class Question(object):
                 raise Text2qtiError(f'Invalid points value "{points}"; need positive integer or half-integer')
             if points_num.is_integer():
                 points_num = int(points)
-            elif abs(points_num-round(points_num)) != 0.5:
+            elif abs(points_num - round(points_num)) != 0.5:
                 raise Text2qtiError(f'Invalid points value "{points}"; need positive integer or half-integer')
             self.points_possible: Union[int, float] = points_num
         self.feedback_raw: Optional[str] = None
@@ -240,18 +261,17 @@ class Question(object):
         self.incorrect_feedback_raw: Optional[str] = None
         self.incorrect_feedback_html_xml: Optional[str] = None
         self.solution: Optional[str] = None
-        h = hashlib.blake2b(self.question_html_xml.encode('utf8'))
+        h = hashlib.blake2b(self.question_html_xml.encode("utf8"))
         self.hash_digest = h.digest()
         self.id = h.hexdigest()[:64]
         self.md = md
 
-
     def append_feedback(self, text: str):
         if self.type is not None and not self.choices:
-            raise Text2qtiError('Question feedback must immediately follow the question')
+            raise Text2qtiError("Question feedback must immediately follow the question")
         if not self.choices:
             if self.feedback_raw is not None:
-                raise Text2qtiError('Feedback can only be specified once')
+                raise Text2qtiError("Feedback can only be specified once")
             self.feedback_raw = text
             self.feedback_html_xml = self.md.md_to_html_xml(text)
             if self.quiz.feedback_is_solution:
@@ -261,94 +281,96 @@ class Question(object):
 
     def append_correct_feedback(self, text: str):
         if self.type is not None:
-            raise Text2qtiError('Correct feedback can only be specified for questions')
+            raise Text2qtiError("Correct feedback can only be specified for questions")
         if self.correct_feedback_raw is not None:
-            raise Text2qtiError('Feedback can only be specified once')
+            raise Text2qtiError("Feedback can only be specified once")
         self.correct_feedback_raw = text
         self.correct_feedback_html_xml = self.md.md_to_html_xml(text)
 
     def append_incorrect_feedback(self, text: str):
         if self.type is not None:
-            raise Text2qtiError('Incorrect feedback can only be specified for questions')
+            raise Text2qtiError("Incorrect feedback can only be specified for questions")
         if self.incorrect_feedback_raw is not None:
-            raise Text2qtiError('Feedback can only be specified once')
+            raise Text2qtiError("Feedback can only be specified once")
         self.incorrect_feedback_raw = text
         self.incorrect_feedback_html_xml = self.md.md_to_html_xml(text)
 
     def append_solution(self, text: str):
         if self.type is not None:
-            raise Text2qtiError('Solutions can only be specified for questions')
+            raise Text2qtiError("Solutions can only be specified for questions")
         if self.solution is not None:
-            raise Text2qtiError('Solutions can only be specified once')
+            raise Text2qtiError("Solutions can only be specified once")
         if self.quiz.feedback_is_solution:
-            raise Text2qtiError('Solutions syntax with "!" is disabled for quizzes with setting "feedback is solution: true"')
+            raise Text2qtiError(
+                'Solutions syntax with "!" is disabled for quizzes with setting "feedback is solution: true"'
+            )
         self.solution = text
 
     def append_mctf_correct_choice(self, text: str):
         if self.type is None:
-            self.type = 'multiple_choice_question'
-        elif self.type != 'multiple_choice_question':
+            self.type = "multiple_choice_question"
+        elif self.type != "multiple_choice_question":
             raise Text2qtiError(f'Question type "{self.type}" does not support multiple choice')
         choice = Choice(text, correct=True, question_hash_digest=self.hash_digest, md=self.md)
         if choice.choice_html_xml in self._choice_set:
-            raise Text2qtiError('Duplicate choice for question')
+            raise Text2qtiError("Duplicate choice for question")
         self._choice_set.add(choice.choice_html_xml)
         self.choices.append(choice)
         self.correct_choices += 1
 
     def append_mctf_incorrect_choice(self, text: str):
         if self.type is None:
-            self.type = 'multiple_choice_question'
-        elif self.type != 'multiple_choice_question':
+            self.type = "multiple_choice_question"
+        elif self.type != "multiple_choice_question":
             raise Text2qtiError(f'Question type "{self.type}" does not support multiple choice')
         choice = Choice(text, correct=False, question_hash_digest=self.hash_digest, md=self.md)
         if choice.choice_html_xml in self._choice_set:
-            raise Text2qtiError('Duplicate choice for question')
+            raise Text2qtiError("Duplicate choice for question")
         self._choice_set.add(choice.choice_html_xml)
         self.choices.append(choice)
 
     def append_shortans_correct_choice(self, text: str):
         if self.type is None:
-            self.type = 'short_answer_question'
-        elif self.type != 'short_answer_question':
+            self.type = "short_answer_question"
+        elif self.type != "short_answer_question":
             raise Text2qtiError(f'Question type "{self.type}" does not support short answer')
         choice = Choice(text, correct=True, shortans=True, question_hash_digest=self.hash_digest, md=self.md)
         if choice.choice_xml in self._choice_set:
-            raise Text2qtiError('Duplicate choice for question')
+            raise Text2qtiError("Duplicate choice for question")
         self._choice_set.add(choice.choice_xml)
         self.choices.append(choice)
         self.correct_choices += 1
 
     def append_multans_correct_choice(self, text: str):
         if self.type is None:
-            self.type = 'multiple_answers_question'
-        elif self.type != 'multiple_answers_question':
+            self.type = "multiple_answers_question"
+        elif self.type != "multiple_answers_question":
             raise Text2qtiError(f'Question type "{self.type}" does not support multiple answers')
         choice = Choice(text, correct=True, question_hash_digest=self.hash_digest, md=self.md)
         if choice.choice_html_xml in self._choice_set:
-            raise Text2qtiError('Duplicate choice for question')
+            raise Text2qtiError("Duplicate choice for question")
         self._choice_set.add(choice.choice_html_xml)
         self.choices.append(choice)
         self.correct_choices += 1
 
     def append_multans_incorrect_choice(self, text: str):
         if self.type is None:
-            self.type = 'multiple_answers_question'
-        elif self.type != 'multiple_answers_question':
+            self.type = "multiple_answers_question"
+        elif self.type != "multiple_answers_question":
             raise Text2qtiError(f'Question type "{self.type}" does not support multiple answers')
         choice = Choice(text, correct=False, question_hash_digest=self.hash_digest, md=self.md)
         if choice.choice_html_xml in self._choice_set:
-            raise Text2qtiError('Duplicate choice for question')
+            raise Text2qtiError("Duplicate choice for question")
         self._choice_set.add(choice.choice_html_xml)
         self.choices.append(choice)
 
     def append_matching_choice(self, text: str):
         if self.type is None:
-            self.type = 'matching_question'
+            self.type = "matching_question"
         choice = Choice(text, correct=False, question_hash_digest=self.hash_digest, md=self.md)
 
         if choice.choice_html_xml in self._choice_set:
-            raise Text2qtiError('Duplicate choice for question')
+            raise Text2qtiError("Duplicate choice for question")
         self._choice_set.add(choice.choice_html_xml)
         self.choices.append(choice)
 
@@ -358,10 +380,10 @@ class Question(object):
             # `text` argument just gives all append functions the same form.
             raise ValueError
         if self.type is not None:
-            if self.type == 'essay_question':
-                raise Text2qtiError(f'Cannot specify essay response multiple times')
+            if self.type == "essay_question":
+                raise Text2qtiError(f"Cannot specify essay response multiple times")
             raise Text2qtiError(f'Question type "{self.type}" does not support essay response')
-        self.type = 'essay_question'
+        self.type = "essay_question"
         if any(x is not None for x in (self.correct_feedback_raw, self.incorrect_feedback_raw)):
             raise Text2qtiError(f'Question type "{self.type}" does not support correct/incorrect feedback')
 
@@ -371,42 +393,46 @@ class Question(object):
             # `text` argument just gives all append functions the same form.
             raise ValueError
         if self.type is not None:
-            if self.type == 'file_upload_question':
-                raise Text2qtiError(f'Cannot specify upload response multiple times')
+            if self.type == "file_upload_question":
+                raise Text2qtiError(f"Cannot specify upload response multiple times")
             raise Text2qtiError(f'Question type "{self.type}" does not support upload response')
-        self.type = 'file_upload_question'
+        self.type = "file_upload_question"
         if any(x is not None for x in (self.correct_feedback_raw, self.incorrect_feedback_raw)):
             raise Text2qtiError(f'Question type "{self.type}" does not support correct/incorrect feedback')
 
     def append_numerical(self, text: str):
         if self.type is not None:
-            if self.type == 'numerical_question':
-                raise Text2qtiError(f'Cannot specify numerical response multiple times')
+            if self.type == "numerical_question":
+                raise Text2qtiError(f"Cannot specify numerical response multiple times")
             raise Text2qtiError(f'Question type "{self.type}" does not support numerical response')
-        self.type = 'numerical_question'
+        self.type = "numerical_question"
         self.numerical_raw = text
-        if text.startswith('['):
-            if not text.endswith(']') or ',' not in text:
-                raise Text2qtiError('Invalid numerical response; need "[<min>, <max>]" or "<number> +- <margin>" or "<integer>"')
-            min, max = text[1:-1].split(',', 1)
+        if text.startswith("["):
+            if not text.endswith("]") or "," not in text:
+                raise Text2qtiError(
+                    'Invalid numerical response; need "[<min>, <max>]" or "<number> +- <margin>" or "<integer>"'
+                )
+            min, max = text[1:-1].split(",", 1)
             try:
                 min = float(min)
                 max = float(max)
             except Exception:
-                raise Text2qtiError('Invalid numerical response; need "[<min>, <max>]" or "<number> +- <margin>" or "<integer>"')
+                raise Text2qtiError(
+                    'Invalid numerical response; need "[<min>, <max>]" or "<number> +- <margin>" or "<integer>"'
+                )
             if min > max:
                 raise Text2qtiError('Invalid numerical response; need "[<min>, <max>]" with min < max')
             self.numerical_min = min
             self.numerical_max = max
             if min.is_integer() and max.is_integer():
-                self.numerical_min_html_xml = f'{min}'
-                self.numerical_max_html_xml = f'{max}'
+                self.numerical_min_html_xml = f"{min}"
+                self.numerical_max_html_xml = f"{max}"
             else:
-                self.numerical_min_html_xml = f'{min:.4f}'
-                self.numerical_max_html_xml = f'{max:.4f}'
-        elif '+-' in text:
-            num, margin = text.split('+-', 1)
-            if margin.endswith('%'):
+                self.numerical_min_html_xml = f"{min:.4f}"
+                self.numerical_max_html_xml = f"{max:.4f}"
+        elif "+-" in text:
+            num, margin = text.split("+-", 1)
+            if margin.endswith("%"):
                 margin_is_percentage = True
                 margin = margin[:-1]
             else:
@@ -415,12 +441,14 @@ class Question(object):
                 num = float(num)
                 margin = float(margin)
             except Exception:
-                raise Text2qtiError('Invalid numerical response; need "[<min>, <max>]" or "<number> +- <margin>" or "<integer>"')
+                raise Text2qtiError(
+                    'Invalid numerical response; need "[<min>, <max>]" or "<number> +- <margin>" or "<integer>"'
+                )
             if margin < 0:
                 raise Text2qtiError('Invalid numerical response; need "<number> +- <margin>" with margin > 0')
             if margin_is_percentage:
-                min = num - abs(num)*(margin/100)
-                max = num + abs(num)*(margin/100)
+                min = num - abs(num) * (margin / 100)
+                max = num + abs(num) * (margin / 100)
             else:
                 min = num - margin
                 max = num + margin
@@ -428,59 +456,59 @@ class Question(object):
             self.numerical_exact = num
             self.numerical_max = max
             if min.is_integer() and num.is_integer() and max.is_integer():
-                self.numerical_min_html_xml = f'{min}'
-                self.numerical_exact_html_xml = f'{num}'
-                self.numerical_max_html_xml = f'{max}'
+                self.numerical_min_html_xml = f"{min}"
+                self.numerical_exact_html_xml = f"{num}"
+                self.numerical_max_html_xml = f"{max}"
             else:
-                self.numerical_min_html_xml = f'{min:.4f}'
-                self.numerical_exact_html_xml = f'{num:.4f}'
-                self.numerical_max_html_xml = f'{max:.4f}'
+                self.numerical_min_html_xml = f"{min:.4f}"
+                self.numerical_exact_html_xml = f"{num:.4f}"
+                self.numerical_max_html_xml = f"{max:.4f}"
         elif int_re.match(text):
             num = int(text)
             min = max = num
             self.numerical_min = min
             self.numerical_exact = num
             self.numerical_max = max
-            self.numerical_min_html_xml = f'{min}'
-            self.numerical_exact_html_xml = f'{num}'
-            self.numerical_max_html_xml = f'{max}'
+            self.numerical_min_html_xml = f"{min}"
+            self.numerical_exact_html_xml = f"{num}"
+            self.numerical_max_html_xml = f"{max}"
         else:
-            raise Text2qtiError('Invalid numerical response; need "[<min>, <max>]" or "<number> +- <margin>" or "<integer>"')
+            raise Text2qtiError(
+                'Invalid numerical response; need "[<min>, <max>]" or "<number> +- <margin>" or "<integer>"'
+            )
         if abs(min) < 1e-4 or abs(max) < 1e-4:
-            raise Text2qtiError('Invalid numerical response; all acceptable values must have a magnitude >= 0.0001')
-
+            raise Text2qtiError("Invalid numerical response; all acceptable values must have a magnitude >= 0.0001")
 
     def finalize(self):
         if self.type is None:
-            raise Text2qtiError('Question must specify a response type')
-        elif self.type == 'multiple_choice_question':
-            if len(self.choices) == 2 and all(c.choice_raw in ('true', 'True', 'false', 'False') for c in self.choices):
-                self.type = 'true_false_question'
+            raise Text2qtiError("Question must specify a response type")
+        elif self.type == "multiple_choice_question":
+            if len(self.choices) == 2 and all(c.choice_raw in ("true", "True", "false", "False") for c in self.choices):
+                self.type = "true_false_question"
             if not self.choices:
-                raise Text2qtiError('Question must provide choices')
+                raise Text2qtiError("Question must provide choices")
             if len(self.choices) < 2:
-                raise Text2qtiError('Question must provide more than one choice')
+                raise Text2qtiError("Question must provide more than one choice")
             if self.correct_choices < 1:
-                raise Text2qtiError('Question must specify a correct choice')
+                raise Text2qtiError("Question must specify a correct choice")
             if self.correct_choices > 1:
-                raise Text2qtiError('Question must specify only one correct choice')
-        elif self.type == 'short_answer_question':
+                raise Text2qtiError("Question must specify only one correct choice")
+        elif self.type == "short_answer_question":
             if not self.choices:
-                raise Text2qtiError('Question must provide at least one answer')
-        elif self.type == 'multiple_answers_question':
+                raise Text2qtiError("Question must provide at least one answer")
+        elif self.type == "multiple_answers_question":
             if len(self.choices) < 2:
-                raise Text2qtiError('Question must provide more than one choice')
+                raise Text2qtiError("Question must provide more than one choice")
             if self.correct_choices < 1:
-                raise Text2qtiError('Question must specify a correct choice')
-
-
+                raise Text2qtiError("Question must specify a correct choice")
 
 
 class Group(object):
-    '''
+    """
     A group of questions.  A random subset of the questions in a group is
     actually displayed.
-    '''
+    """
+
     def __init__(self):
         self.pick = 1
         self._pick_is_set = False
@@ -490,11 +518,11 @@ class Group(object):
         self.questions: List[Question] = []
         self._question_points_possible: Optional[Union[int, float]] = None
         self.title_raw: Optional[str] = None
-        self.title_xml = 'Group'
+        self.title_xml = "Group"
 
     def append_group_pick(self, text: str):
         if self.questions:
-            raise Text2qtiError('Question group options must be set at the very start of the group')
+            raise Text2qtiError("Question group options must be set at the very start of the group")
         if self._pick_is_set:
             Text2qtiError('"Pick" has already been set for this question group')
         try:
@@ -509,7 +537,7 @@ class Group(object):
 
     def append_group_solutions_pick(self, text: str):
         if self.questions:
-            raise Text2qtiError('Question group options must be set at the very start of the group')
+            raise Text2qtiError("Question group options must be set at the very start of the group")
         if self.solutions_pick is not None:
             Text2qtiError('"solutions pick" has already been set for this question group')
         try:
@@ -523,7 +551,7 @@ class Group(object):
 
     def append_group_points_per_question(self, text: str):
         if self.questions:
-            raise Text2qtiError('Question group options must be set at the very start of the group')
+            raise Text2qtiError("Question group options must be set at the very start of the group")
         if self._points_per_question_is_set:
             Text2qtiError('"Points per question" has already been set for this question group')
         try:
@@ -538,48 +566,60 @@ class Group(object):
         if self._question_points_possible is None:
             self._question_points_possible = question.points_possible
         elif question.points_possible != self._question_points_possible:
-            raise Text2qtiError('Question groups must only contain questions with the same point value')
+            raise Text2qtiError("Question groups must only contain questions with the same point value")
         self.questions.append(question)
 
     def finalize(self):
         if len(self.questions) < self.pick:
-            raise Text2qtiError(f'Question group only contains {len(self.questions)} questions, needs at least {self.pick+1}')
+            raise Text2qtiError(
+                f"Question group only contains {len(self.questions)} questions, needs at least {self.pick+1}"
+            )
         if self.solutions_pick is not None and len(self.questions) < self.solutions_pick:
-            raise Text2qtiError(f'Question group only contains {len(self.questions)} questions, needs at least {self.solutions_pick}')
+            raise Text2qtiError(
+                f"Question group only contains {len(self.questions)} questions, needs at least {self.solutions_pick}"
+            )
         h = hashlib.blake2b()
         for digest in sorted(q.hash_digest for q in self.questions):
             h.update(digest)
         self.hash_digest = h.digest()
         self.id = h.hexdigest()[:64]
 
+
 class GroupStart(object):
-    '''
+    """
     Start delim for a group of questions.
-    '''
+    """
+
     def __init__(self, group: Group):
         self.group = group
+
 
 class GroupEnd(object):
-    '''
+    """
     End delim for a group of questions.
-    '''
+    """
+
     def __init__(self, group: Group):
         self.group = group
-
-
 
 
 class Quiz(object):
-    '''
+    """
     A quiz or assessment.  Contains a list of questions along with possible
     choices and feedback.
-    '''
-    def __init__(self, string: str, *, config: Config,
-                 source_name: Optional[str]=None,
-                 resource_path: Optional[Union[str, pathlib.Path]]=None):
+    """
+
+    def __init__(
+        self,
+        string: str,
+        *,
+        config: Config,
+        source_name: Optional[str] = None,
+        resource_path: Optional[Union[str, pathlib.Path]] = None,
+    ):
         self.string = string
         self.config = config
-        self.source_name = '<string>' if source_name is None else f'"{source_name}"'
+        self.source_name = "<string>" if source_name is None else f'"{source_name}"'
         if resource_path is not None:
             if isinstance(resource_path, str):
                 resource_path = pathlib.Path(resource_path)
@@ -589,17 +629,17 @@ class Quiz(object):
                 raise Text2qtiError(f'Resource path "{resource_path.as_posix()}" does not exist')
         self.resource_path = resource_path
         self.title_raw = None
-        self.title_xml = 'Quiz'
+        self.title_xml = "Quiz"
         self.description_raw = None
-        self.description_html_xml = ''
+        self.description_html_xml = ""
         self.shuffle_answers_raw = None
-        self.shuffle_answers_xml = 'false'
+        self.shuffle_answers_xml = "false"
         self.show_correct_answers_raw = None
-        self.show_correct_answers_xml = 'true'
+        self.show_correct_answers_xml = "true"
         self.one_question_at_a_time_raw = None
-        self.one_question_at_a_time_xml = 'false'
+        self.one_question_at_a_time_xml = "false"
         self.cant_go_back_raw = None
-        self.cant_go_back_xml = 'false'
+        self.cant_go_back_xml = "false"
         self.feedback_is_solution: Optional[bool] = None
         self.solutions_sample_groups: Optional[bool] = None
         self.solutions_randomize_groups: Optional[bool] = None
@@ -616,23 +656,23 @@ class Quiz(object):
         # Determine how to interpret `.python` for executable code blocks.
         # If `python3` exists, use it instead of `python` if `python` does not
         # exist or if `python` is equivalent to `python2`.
-        if not shutil.which('python2') or not shutil.which('python3'):
-            python_executable = 'python'
-        elif not shutil.which('python'):
-            python_executable = 'python3'
-        elif pathlib.Path(shutil.which('python')).resolve() == pathlib.Path(shutil.which('python2')).resolve():
-            python_executable = 'python3'
+        if not shutil.which("python2") or not shutil.which("python3"):
+            python_executable = "python"
+        elif not shutil.which("python"):
+            python_executable = "python3"
+        elif pathlib.Path(shutil.which("python")).resolve() == pathlib.Path(shutil.which("python2")).resolve():
+            python_executable = "python3"
         else:
-            python_executable = 'python'
+            python_executable = "python"
 
         try:
             parse_actions = {}
             for k in start_patterns:
-                parse_actions[k] = getattr(self, f'append_{k}')
+                parse_actions[k] = getattr(self, f"append_{k}")
             parse_actions[None] = self.append_unknown
-            start_multiline_comment_pattern = comment_patterns['start_multiline_comment']
-            end_multiline_comment_pattern = comment_patterns['end_multiline_comment']
-            line_comment_pattern = comment_patterns['line_comment']
+            start_multiline_comment_pattern = comment_patterns["start_multiline_comment"]
+            end_multiline_comment_pattern = comment_patterns["end_multiline_comment"]
+            line_comment_pattern = comment_patterns["line_comment"]
             n_line_iter = iter(x for x in enumerate(string.splitlines()))
             n, line = next(n_line_iter, (0, None))
             lookahead = False
@@ -641,94 +681,113 @@ class Quiz(object):
                 match = start_re.match(line)
                 if match:
                     action = match.lastgroup
-                    text = line[match.end():].strip()
-                    if action == 'start_code':
-                        info = line.lstrip('`').strip()
+                    text = line[match.end() :].strip()
+                    if action == "start_code":
+                        info = line.lstrip("`").strip()
                         info_match = start_code_supported_info_re.match(info)
                         if info_match is None:
                             pass
                         else:
-                            executable = info_match.group('executable')
+                            executable = info_match.group("executable")
                             if executable is not None:
                                 if executable.startswith('"'):
                                     executable = executable[1:-1]
                                 executable = pathlib.Path(executable).expanduser().as_posix()
                             else:
-                                executable = info_match.group('lang')
-                                if executable == 'python':
+                                executable = info_match.group("lang")
+                                if executable == "python":
                                     executable = python_executable
-                            delim = '`'*(len(line) - len(line.lstrip('`')))
+                            delim = "`" * (len(line) - len(line.lstrip("`")))
                             n_code_start = n
                             code_lines = []
                             n, line = next(n_line_iter, (0, None))
                             # No lookahead here; all lines are consumed
-                            while line is not None and not (line.startswith(delim) and line[len(delim):] == line.lstrip('`')):
+                            while line is not None and not (
+                                line.startswith(delim) and line[len(delim) :] == line.lstrip("`")
+                            ):
                                 code_lines.append(line)
                                 n, line = next(n_line_iter, (0, None))
                             if line is None:
-                                raise Text2qtiError(f'In {self.source_name} on line {n}:\nCode closing fence is missing')
-                            if line.lstrip('`').strip():
-                                raise Text2qtiError(f'In {self.source_name} on line {n+1}:\nCode closing fence is missing')
-                            code_lines.append('\n')
-                            code = '\n'.join(code_lines)
+                                raise Text2qtiError(
+                                    f"In {self.source_name} on line {n}:\nCode closing fence is missing"
+                                )
+                            if line.lstrip("`").strip():
+                                raise Text2qtiError(
+                                    f"In {self.source_name} on line {n+1}:\nCode closing fence is missing"
+                                )
+                            code_lines.append("\n")
+                            code = "\n".join(code_lines)
                             try:
                                 stdout = self._run_code(executable, code)
                             except Exception as e:
-                                raise Text2qtiError(f'In {self.source_name} on line {n_code_start+1}:\n{e}')
+                                raise Text2qtiError(f"In {self.source_name} on line {n_code_start+1}:\n{e}")
                             code_n_line_iter = ((n_code_start, stdout_line) for stdout_line in stdout.splitlines())
                             n_line_iter = itertools.chain(code_n_line_iter, n_line_iter)
                             n, line = next(n_line_iter, (0, None))
                             continue
                     elif action in multi_line:
-                        if start_patterns[action].endswith(':'):
+                        if start_patterns[action].endswith(":"):
                             indent_expandtabs = None
                         else:
-                            indent_expandtabs = ' '*len(line[:match.end()].expandtabs(4))
+                            indent_expandtabs = " " * len(line[: match.end()].expandtabs(4))
                         text_lines = [text]
                         n, line = next(n_line_iter, (0, None))
                         line_expandtabs = line.expandtabs(4) if line is not None else None
                         lookahead = True
-                        while (line is not None and
-                                (not line or line.isspace() or
-                                    indent_expandtabs is None or line_expandtabs.startswith(indent_expandtabs))):
+                        while line is not None and (
+                            not line
+                            or line.isspace()
+                            or indent_expandtabs is None
+                            or line_expandtabs.startswith(indent_expandtabs)
+                        ):
                             if not line or line.isspace():
                                 if action in multi_para:
-                                    text_lines.append('')
+                                    text_lines.append("")
                                 else:
                                     break
                             else:
                                 if indent_expandtabs is None:
-                                    if not line.startswith((' ', '\t')):
+                                    if not line.startswith((" ", "\t")):
                                         break
-                                    indent_expandtabs = ' '*(len(line_expandtabs)-len(line_expandtabs.lstrip(' ')))
+                                    indent_expandtabs = " " * (len(line_expandtabs) - len(line_expandtabs.lstrip(" ")))
                                     if len(indent_expandtabs) < 2:
-                                        raise Text2qtiError(f'In {self.source_name} on line {n+1}:\nIndentation must be at least 2 spaces or 1 tab here')
+                                        raise Text2qtiError(
+                                            f"In {self.source_name} on line {n+1}:\nIndentation must be at least 2 spaces or 1 tab here"
+                                        )
                                 # The `rstrip()` prevents trailing double
                                 # spaces from becoming `<br />`.
-                                text_lines.append(line_expandtabs[len(indent_expandtabs):].rstrip())
+                                text_lines.append(line_expandtabs[len(indent_expandtabs) :].rstrip())
                             n, line = next(n_line_iter, (0, None))
                             line_expandtabs = line.expandtabs(4) if line is not None else None
                         if text_lines and not text_lines[-1]:
                             while text_lines and not text_lines[-1]:
                                 text_lines.pop()
-                        text = '\n'.join(text_lines)
+                        text = "\n".join(text_lines)
                 elif line.startswith(line_comment_pattern):
                     n, line = next(n_line_iter, (0, None))
                     continue
                 elif line.startswith(start_multiline_comment_pattern):
                     if line.strip() != start_multiline_comment_pattern:
-                        raise Text2qtiError(f'In {self.source_name} on line {n+1}:\nUnexpected content after "{start_multiline_comment_pattern}"')
+                        raise Text2qtiError(
+                            f'In {self.source_name} on line {n+1}:\nUnexpected content after "{start_multiline_comment_pattern}"'
+                        )
                     n, line = next(n_line_iter, (0, None))
                     while line is not None and not line.startswith(end_multiline_comment_pattern):
                         n, line = next(n_line_iter, (0, None))
                     if line is None:
-                        raise Text2qtiError(f'In {self.source_name} on line {n+1}:\nf"{start_multiline_comment_pattern}" without following "{end_multiline_comment_pattern}"')
+                        raise Text2qtiError(
+                            f'In {self.source_name} on line {n+1}:\nf"{start_multiline_comment_pattern}" without following "{end_multiline_comment_pattern}"'
+                        )
                     if line.strip() != end_multiline_comment_pattern:
-                        raise Text2qtiError(f'In {self.source_name} on line {n+1}:\nUnexpected content after "{end_multiline_comment_pattern}"')
+                        raise Text2qtiError(
+                            f'In {self.source_name} on line {n+1}:\nUnexpected content after "{end_multiline_comment_pattern}"'
+                        )
                     n, line = next(n_line_iter, (0, None))
                     continue
                 elif line.startswith(end_multiline_comment_pattern):
-                    raise Text2qtiError(f'In {self.source_name} on line {n+1}:\n"{end_multiline_comment_pattern}" without preceding "{start_multiline_comment_pattern}"')
+                    raise Text2qtiError(
+                        f'In {self.source_name} on line {n+1}:\n"{end_multiline_comment_pattern}" without preceding "{start_multiline_comment_pattern}"'
+                    )
                 else:
                     action = None
                     text = line
@@ -736,21 +795,23 @@ class Quiz(object):
                     parse_actions[action](text)
                 except Text2qtiError as e:
                     if lookahead and n != n_code_start:
-                        raise Text2qtiError(f'In {self.source_name} on line {n}:\n{e}')
-                    raise Text2qtiError(f'In {self.source_name} on line {n+1}:\n{e}')
+                        raise Text2qtiError(f"In {self.source_name} on line {n}:\n{e}")
+                    raise Text2qtiError(f"In {self.source_name} on line {n+1}:\n{e}")
                 if not lookahead:
                     n, line = next(n_line_iter, (0, None))
                 lookahead = False
             if not self.questions_and_delims:
-                raise Text2qtiError('No questions were found')
+                raise Text2qtiError("No questions were found")
             if self._current_group is not None:
-                raise Text2qtiError(f'In {self.source_name} on line {len(string.splitlines())}:\nQuestion group never ended')
+                raise Text2qtiError(
+                    f"In {self.source_name} on line {len(string.splitlines())}:\nQuestion group never ended"
+                )
             last_question_or_delim = self.questions_and_delims[-1]
             if isinstance(last_question_or_delim, Question):
                 try:
                     last_question_or_delim.finalize()
                 except Text2qtiError as e:
-                    raise Text2qtiError(f'In {self.source_name} on line {len(string.splitlines())}:\n{e}')
+                    raise Text2qtiError(f"In {self.source_name} on line {len(string.splitlines())}:\n{e}")
 
             points_possible = 0
             digests = []
@@ -759,7 +820,7 @@ class Quiz(object):
                     points_possible += x.points_possible
                     digests.append(x.hash_digest)
                 elif isinstance(x, GroupStart):
-                    points_possible += x.group.points_per_question*x.group.pick
+                    points_possible += x.group.points_per_question * x.group.pick
                     digests.append(x.group.hash_digest)
                 elif isinstance(x, GroupEnd):
                     pass
@@ -777,11 +838,13 @@ class Quiz(object):
             self.md.finalize()
 
     def _run_code(self, executable: str, code: str) -> str:
-        if not self.config['run_code_blocks']:
-            raise Text2qtiError('Code execution for code blocks is not enabled; use --run-code-blocks, or set run_code_blocks = true in config')
+        if not self.config["run_code_blocks"]:
+            raise Text2qtiError(
+                "Code execution for code blocks is not enabled; use --run-code-blocks, or set run_code_blocks = true in config"
+            )
         h = hashlib.blake2b()
-        h.update(code.encode('utf8'))
-        if platform.system() == 'Windows':
+        h.update(code.encode("utf8"))
+        if platform.system() == "Windows":
             # Prevent console from appearing for an instant
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
@@ -789,9 +852,9 @@ class Quiz(object):
             startupinfo = None
         with tempfile.TemporaryDirectory() as tempdir:
             tempdir_path = pathlib.Path(tempdir)
-            code_path = tempdir_path / f'{h.hexdigest()[:16]}.code'
-            code_path.write_text(code, encoding='utf8')
-            if platform.system() == 'Windows':
+            code_path = tempdir_path / f"{h.hexdigest()[:16]}.code"
+            code_path.write_text(code, encoding="utf8")
+            if platform.system() == "Windows":
                 # Modify executable since subprocess.Popen() ignores PATH
                 # * https://bugs.python.org/issue15451
                 # * https://bugs.python.org/issue8557
@@ -804,9 +867,9 @@ class Quiz(object):
             try:
                 # stdin is needed for GUI because standard file handles can't
                 # be inherited
-                proc = subprocess.run(cmd,
-                                      stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE,
-                                      startupinfo=startupinfo)
+                proc = subprocess.run(
+                    cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, startupinfo=startupinfo
+                )
             except FileNotFoundError as e:
                 raise Text2qtiError(f'Failed to execute code (missing executable "{executable}"?):\n{e}')
             except Exception as e:
@@ -814,140 +877,153 @@ class Quiz(object):
         # Use io to handle output as if read from a file in terms of newline
         # treatment
         if proc.returncode != 0:
-            stderr_str = io.TextIOWrapper(io.BytesIO(proc.stderr),
-                                          encoding=locale.getpreferredencoding(False),
-                                          errors='backslashreplace').read()
+            stderr_str = io.TextIOWrapper(
+                io.BytesIO(proc.stderr), encoding=locale.getpreferredencoding(False), errors="backslashreplace"
+            ).read()
             raise Text2qtiError(f'Code execution resulted in errors:\n{"-"*50}\n{stderr_str}\n{"-"*50}')
         try:
-            stdout_str = io.TextIOWrapper(io.BytesIO(proc.stdout),
-                                          encoding=locale.getpreferredencoding(False)).read()
+            stdout_str = io.TextIOWrapper(io.BytesIO(proc.stdout), encoding=locale.getpreferredencoding(False)).read()
         except Exception as e:
-            raise Text2qtiError(f'Failed to decode output of executed code:\n{e}')
+            raise Text2qtiError(f"Failed to decode output of executed code:\n{e}")
         return stdout_str
 
     def append_quiz_title(self, text: str):
-        if any(x is not None for x in (self.shuffle_answers_raw, self.show_correct_answers_raw,
-                                       self.one_question_at_a_time_raw, self.cant_go_back_raw)):
-            raise Text2qtiError('Must give quiz title before quiz options')
+        if any(
+            x is not None
+            for x in (
+                self.shuffle_answers_raw,
+                self.show_correct_answers_raw,
+                self.one_question_at_a_time_raw,
+                self.cant_go_back_raw,
+            )
+        ):
+            raise Text2qtiError("Must give quiz title before quiz options")
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.title_raw is not None:
-            raise Text2qtiError('Quiz title has already been given')
+            raise Text2qtiError("Quiz title has already been given")
         if self.questions_and_delims:
-            raise Text2qtiError('Must give quiz title before questions')
+            raise Text2qtiError("Must give quiz title before questions")
         if self.description_raw is not None:
-            raise Text2qtiError('Must give quiz title before quiz description')
+            raise Text2qtiError("Must give quiz title before quiz description")
         self.title_raw = text
         self.title_xml = self.md.xml_escape(text)
 
     def append_quiz_description(self, text: str):
-        if any(x is not None for x in (self.shuffle_answers_raw, self.show_correct_answers_raw,
-                                       self.one_question_at_a_time_raw, self.cant_go_back_raw)):
-            raise Text2qtiError('Must give quiz description before quiz options')
+        if any(
+            x is not None
+            for x in (
+                self.shuffle_answers_raw,
+                self.show_correct_answers_raw,
+                self.one_question_at_a_time_raw,
+                self.cant_go_back_raw,
+            )
+        ):
+            raise Text2qtiError("Must give quiz description before quiz options")
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.description_raw is not None:
-            raise Text2qtiError('Quiz description has already been given')
+            raise Text2qtiError("Quiz description has already been given")
         if self.questions_and_delims:
-            raise Text2qtiError('Must give quiz description before questions')
+            raise Text2qtiError("Must give quiz description before questions")
         self.description_raw = text
         self.description_html_xml = self.md.md_to_html_xml(text)
 
     def append_quiz_shuffle_answers(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.questions_and_delims:
-            raise Text2qtiError('Must give quiz options before questions')
+            raise Text2qtiError("Must give quiz options before questions")
         if self.shuffle_answers_raw is not None:
             raise Text2qtiError('Quiz option "Shuffle answers" has already been set')
-        if text not in ('true', 'True', 'false', 'False'):
+        if text not in ("true", "True", "false", "False"):
             raise Text2qtiError('Expected option value "true" or "false"')
         self.shuffle_answers_raw = text
         self.shuffle_answers_xml = text.lower()
 
     def append_quiz_show_correct_answers(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.questions_and_delims:
-            raise Text2qtiError('Must give quiz options before questions')
+            raise Text2qtiError("Must give quiz options before questions")
         if self.show_correct_answers_raw is not None:
             raise Text2qtiError('Quiz option "Show correct answers" has already been set')
-        if text not in ('true', 'True', 'false', 'False'):
+        if text not in ("true", "True", "false", "False"):
             raise Text2qtiError('Expected option value "true" or "false"')
         self.show_correct_answers_raw = text
         self.show_correct_answers_xml = text.lower()
 
     def append_quiz_one_question_at_a_time(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.questions_and_delims:
-            raise Text2qtiError('Must give quiz options before questions')
+            raise Text2qtiError("Must give quiz options before questions")
         if self.one_question_at_a_time_raw is not None:
             raise Text2qtiError('Quiz option "One question at a time" has already been set')
-        if text not in ('true', 'True', 'false', 'False'):
+        if text not in ("true", "True", "false", "False"):
             raise Text2qtiError('Expected option value "true" or "false"')
         self.one_question_at_a_time_raw = text
         self.one_question_at_a_time_xml = text.lower()
 
     def append_quiz_cant_go_back(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.questions_and_delims:
-            raise Text2qtiError('Must give quiz options before questions')
+            raise Text2qtiError("Must give quiz options before questions")
         if self.cant_go_back_raw is not None:
-            raise Text2qtiError('''Quiz option "Can't go back" has already been set''')
-        if text not in ('true', 'True', 'false', 'False'):
+            raise Text2qtiError("""Quiz option "Can't go back" has already been set""")
+        if text not in ("true", "True", "false", "False"):
             raise Text2qtiError('Expected option value "true" or "false"')
-        if self.one_question_at_a_time_xml != 'true':
+        if self.one_question_at_a_time_xml != "true":
             raise Text2qtiError('''Must set "One question at a time" to "true" before setting "Can't go back"''')
         self.cant_go_back_raw = text
         self.cant_go_back_xml = text.lower()
 
     def append_quiz_feedback_is_solution(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.questions_and_delims:
-            raise Text2qtiError('Must give quiz options before questions')
+            raise Text2qtiError("Must give quiz options before questions")
         if self.feedback_is_solution is not None:
             raise Text2qtiError('Quiz option "feedback is solution" has already been set')
-        if text in ('true', 'True'):
+        if text in ("true", "True"):
             self.feedback_is_solution = True
-        elif text in ('false', 'False'):
+        elif text in ("false", "False"):
             self.feedback_is_solution = False
         else:
             raise Text2qtiError('Expected option value "true" or "false"')
 
     def append_quiz_solutions_sample_groups(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.questions_and_delims:
-            raise Text2qtiError('Must give quiz options before questions')
+            raise Text2qtiError("Must give quiz options before questions")
         if self.solutions_sample_groups is not None:
             raise Text2qtiError('Quiz option "solutions sample groups" has already been set')
-        if text in ('true', 'True'):
+        if text in ("true", "True"):
             self.solutions_sample_groups = True
-        elif text in ('false', 'False'):
+        elif text in ("false", "False"):
             self.solutions_sample_groups = False
         else:
             raise Text2qtiError('Expected option value "true" or "false"')
 
     def append_quiz_solutions_randomize_groups(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.questions_and_delims:
-            raise Text2qtiError('Must give quiz options before questions')
+            raise Text2qtiError("Must give quiz options before questions")
         if self.solutions_randomize_groups is not None:
             raise Text2qtiError('Quiz option "solutions randomize groups" has already been set')
-        if text in ('true', 'True'):
+        if text in ("true", "True"):
             self.solutions_randomize_groups = True
-        elif text in ('false', 'False'):
+        elif text in ("false", "False"):
             self.solutions_randomize_groups = False
         else:
             raise Text2qtiError('Expected option value "true" or "false"')
 
     def append_text_title(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.questions_and_delims:
             last_question_or_delim = self.questions_and_delims[-1]
             if isinstance(last_question_or_delim, Question):
@@ -958,7 +1034,7 @@ class Quiz(object):
 
     def append_text(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self.questions_and_delims:
             last_question_or_delim = self.questions_and_delims[-1]
             if isinstance(last_question_or_delim, Question):
@@ -979,171 +1055,175 @@ class Quiz(object):
             last_question_or_delim = self.questions_and_delims[-1]
             if isinstance(last_question_or_delim, Question):
                 last_question_or_delim.finalize()
-        question = Question(text,
-                            quiz=self,
-                            title=self._next_question_attr.get('title'),
-                            points=self._next_question_attr.get('points'),
-                            md=self.md)
+        question = Question(
+            text,
+            quiz=self,
+            title=self._next_question_attr.get("title"),
+            points=self._next_question_attr.get("points"),
+            md=self.md,
+        )
         self._next_question_attr = {}
         if question.question_html_xml in self.question_set:
-            raise Text2qtiError('Duplicate question')
+            raise Text2qtiError("Duplicate question")
         self.question_set.add(question.question_html_xml)
         self.questions_and_delims.append(question)
         if self._current_group is not None:
             self._current_group.append_question(question)
 
     def append_question_title(self, text: str):
-        if 'title' in self._next_question_attr:
-            raise Text2qtiError('Title for next question has already been set')
-        if 'points' in self._next_question_attr:
-            raise Text2qtiError('Title for next question must be set before point value')
-        self._next_question_attr['title'] = text
+        if "title" in self._next_question_attr:
+            raise Text2qtiError("Title for next question has already been set")
+        if "points" in self._next_question_attr:
+            raise Text2qtiError("Title for next question must be set before point value")
+        self._next_question_attr["title"] = text
 
     def append_question_points(self, text: str):
-        if 'points' in self._next_question_attr:
-            raise Text2qtiError('Points for next question has already been set')
-        self._next_question_attr['points'] = text
+        if "points" in self._next_question_attr:
+            raise Text2qtiError("Points for next question has already been set")
+        self._next_question_attr["points"] = text
 
     def append_feedback(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have feedback without a question')
+            raise Text2qtiError("Cannot have feedback without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have feedback without a question')
+            raise Text2qtiError("Cannot have feedback without a question")
         last_question_or_delim.append_feedback(text)
 
     def append_correct_feedback(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have feedback without a question')
+            raise Text2qtiError("Cannot have feedback without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have feedback without a question')
+            raise Text2qtiError("Cannot have feedback without a question")
         last_question_or_delim.append_correct_feedback(text)
 
     def append_incorrect_feedback(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have feedback without a question')
+            raise Text2qtiError("Cannot have feedback without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have feedback without a question')
+            raise Text2qtiError("Cannot have feedback without a question")
         last_question_or_delim.append_incorrect_feedback(text)
 
     def append_solution(self, text: str):
         if self.feedback_is_solution:
-            raise Text2qtiError('Quiz option "feedback is solution" is "true"; '
-                                '"!" solution syntax is disabled and solutions must be provided as feedback ("...") rather than separately')
+            raise Text2qtiError(
+                'Quiz option "feedback is solution" is "true"; '
+                '"!" solution syntax is disabled and solutions must be provided as feedback ("...") rather than separately'
+            )
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have a solution without a question')
+            raise Text2qtiError("Cannot have a solution without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have a solution without a question')
+            raise Text2qtiError("Cannot have a solution without a question")
         last_question_or_delim.append_solution(text)
 
     def append_mctf_correct_choice(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have a choice without a question')
+            raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have a choice without a question')
+            raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim.append_mctf_correct_choice(text)
 
     def append_mctf_incorrect_choice(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have a choice without a question')
+            raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have a choice without a question')
+            raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim.append_mctf_incorrect_choice(text)
 
     def append_shortans_correct_choice(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have an answer without a question')
+            raise Text2qtiError("Cannot have an answer without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have an answer without a question')
+            raise Text2qtiError("Cannot have an answer without a question")
         last_question_or_delim.append_shortans_correct_choice(text)
 
     def append_multans_correct_choice(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have a choice without a question')
+            raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have a choice without a question')
+            raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim.append_multans_correct_choice(text)
 
     def append_multans_incorrect_choice(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have a choice without a question')
+            raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have a choice without a question')
+            raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim.append_multans_incorrect_choice(text)
 
     def append_matching_choice(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have a choice without a question')
+            raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have a choice without a question')
+            raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim.append_matching_choice(text)
 
     def append_essay(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have an essay response without a question')
+            raise Text2qtiError("Cannot have an essay response without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have an essay response without a question')
+            raise Text2qtiError("Cannot have an essay response without a question")
         last_question_or_delim.append_essay(text)
 
     def append_upload(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have an upload response without a question')
+            raise Text2qtiError("Cannot have an upload response without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have an upload response without a question')
+            raise Text2qtiError("Cannot have an upload response without a question")
         last_question_or_delim.append_upload(text)
 
     def append_numerical(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if not self.questions_and_delims:
-            raise Text2qtiError('Cannot have a numerical response without a question')
+            raise Text2qtiError("Cannot have a numerical response without a question")
         last_question_or_delim = self.questions_and_delims[-1]
         if not isinstance(last_question_or_delim, Question):
-            raise Text2qtiError('Cannot have a numerical response without a question')
+            raise Text2qtiError("Cannot have a numerical response without a question")
         last_question_or_delim.append_numerical(text)
 
     def append_start_group(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if text:
             raise ValueError
         if self._current_group is not None:
-            raise Text2qtiError('Question groups cannot be nested')
+            raise Text2qtiError("Question groups cannot be nested")
         if self.questions_and_delims:
             last_question_or_delim = self.questions_and_delims[-1]
             if isinstance(last_question_or_delim, Question):
@@ -1154,11 +1234,11 @@ class Quiz(object):
 
     def append_end_group(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if text:
             raise ValueError
         if self._current_group is None:
-            raise Text2qtiError('No question group to end')
+            raise Text2qtiError("No question group to end")
         if self.questions_and_delims:
             last_question_or_delim = self.questions_and_delims[-1]
             if isinstance(last_question_or_delim, Question):
@@ -1169,34 +1249,34 @@ class Quiz(object):
 
     def append_group_pick(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self._current_group is None:
-            raise Text2qtiError('No question group for setting properties')
+            raise Text2qtiError("No question group for setting properties")
         self._current_group.append_group_pick(text)
 
     def append_group_solutions_pick(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self._current_group is None:
-            raise Text2qtiError('No question group for setting properties')
+            raise Text2qtiError("No question group for setting properties")
         self._current_group.append_group_solutions_pick(text)
 
     def append_group_points_per_question(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if self._current_group is None:
-            raise Text2qtiError('No question group for setting properties')
+            raise Text2qtiError("No question group for setting properties")
         self._current_group.append_group_points_per_question(text)
 
     def append_start_code(self, text: str):
-        raise Text2qtiError('Invalid code block start')
+        raise Text2qtiError("Invalid code block start")
 
     def append_end_code(self, text: str):
-        raise Text2qtiError('Code block end missing code block start')
+        raise Text2qtiError("Code block end missing code block start")
 
     def append_unknown(self, text: str):
         if self._next_question_attr:
-            raise Text2qtiError('Expected question; question title and/or points were set but not used')
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
         if text and not text.isspace():
             match = start_missing_whitespace_re.match(text)
             if match:
@@ -1204,4 +1284,6 @@ class Quiz(object):
             match = start_missing_content_re.match(text)
             if match:
                 raise Text2qtiError(f'Missing content after "{match.group().strip()}"')
-            raise Text2qtiError(f'Syntax error; unexpected text, or incorrect indentation for a wrapped paragraph:\n"{text}"')
+            raise Text2qtiError(
+                f'Syntax error; unexpected text, or incorrect indentation for a wrapped paragraph:\n"{text}"'
+            )

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -38,6 +38,7 @@ start_patterns = {
     "multans_incorrect_choice": r"\[ ?\]",
     "shortans_correct_choice": r"\*",
     "matching_choice": r">",
+    "ordering_choice": r"~",
     "feedback": r"\.\.\.",
     "correct_feedback": r"\+",
     "incorrect_feedback": r"\-",
@@ -367,6 +368,16 @@ class Question(object):
     def append_matching_choice(self, text: str):
         if self.type is None:
             self.type = "matching_question"
+        choice = Choice(text, correct=False, question_hash_digest=self.hash_digest, md=self.md)
+
+        if choice.choice_html_xml in self._choice_set:
+            raise Text2qtiError("Duplicate choice for question")
+        self._choice_set.add(choice.choice_html_xml)
+        self.choices.append(choice)
+
+    def append_ordering_choice(self, text: str):
+        if self.type is None:
+            self.type = "ordering_question"
         choice = Choice(text, correct=False, question_hash_digest=self.hash_digest, md=self.md)
 
         if choice.choice_html_xml in self._choice_set:
@@ -1186,6 +1197,16 @@ class Quiz(object):
         if not isinstance(last_question_or_delim, Question):
             raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim.append_matching_choice(text)
+
+    def append_ordering_choice(self, text: str):
+        if self._next_question_attr:
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
+        if not self.questions_and_delims:
+            raise Text2qtiError("Cannot have a choice without a question")
+        last_question_or_delim = self.questions_and_delims[-1]
+        if not isinstance(last_question_or_delim, Question):
+            raise Text2qtiError("Cannot have a choice without a question")
+        last_question_or_delim.append_ordering_choice(text)
 
     def append_essay(self, text: str):
         if self._next_question_attr:

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -29,6 +29,8 @@ from .config import Config
 from .err import Text2qtiError
 from .markdown import Image, Markdown
 
+TRUE_FALSE_ALTERNATIVES = ("true", "True", "sant", "Sant", "false", "False", "falskt", "Falskt")
+
 # regex patterns for parsing quiz content
 start_patterns = {
     "question": r"\d+\.",
@@ -520,7 +522,7 @@ class Question(object):
         if self.type is None:
             raise Text2qtiError("Question must specify a response type")
         elif self.type == "multiple_choice_question":
-            if len(self.choices) == 2 and all(c.choice_raw in ("true", "True", "false", "False") for c in self.choices):
+            if len(self.choices) == 2 and all(c.choice_raw in TRUE_FALSE_ALTERNATIVES for c in self.choices):
                 self.type = "true_false_question"
             if not self.choices:
                 raise Text2qtiError("Question must provide choices")

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -176,7 +176,16 @@ class Choice(object):
     The presence of feedback does not affect the id.
     """
 
-    def __init__(self, text: str, *, correct: bool, shortans: bool = False, question_hash_digest: bytes, md: Markdown):
+    def __init__(
+        self,
+        text: str,
+        *,
+        correct: bool,
+        shortans: bool = False,
+        question_hash_digest: bytes,
+        md: Markdown,
+        distractor: bool = False,
+    ):
         self.choice_raw = text
         if shortans:
             self.choice_xml = md.xml_escape(text)
@@ -186,6 +195,7 @@ class Choice(object):
         self.shortans = shortans
         self.feedback_raw: Optional[str] = None
         self.feedback_html_xml: Optional[str] = None
+        self.distractor: bool = distractor
         # ID is based on hash of choice XML as well as question XML.  This
         # gives different IDs for identical choices in different questions.
         if shortans:
@@ -266,6 +276,7 @@ class Question(object):
         self.hash_digest = h.digest()
         self.id = h.hexdigest()[:64]
         self.md = md
+        self.n_distractors: int = 0
 
     def append_feedback(self, text: str):
         if self.type is not None and not self.choices:
@@ -368,7 +379,22 @@ class Question(object):
     def append_matching_choice(self, text: str):
         if self.type is None:
             self.type = "matching_question"
-        choice = Choice(text, correct=False, question_hash_digest=self.hash_digest, md=self.md)
+        pattern = r"(.*)\s->\s(.*)"
+        match = re.match(pattern, text)
+        if match:
+            question_str = match.group(1)
+            if question_str == "_":
+                distractor = True
+                self.n_distractors += 1
+            else:
+                distractor = False
+        choice = Choice(
+            text,
+            correct=False,
+            distractor=distractor,
+            question_hash_digest=self.hash_digest,
+            md=self.md,
+        )
 
         if choice.choice_html_xml in self._choice_set:
             raise Text2qtiError("Duplicate choice for question")

--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -41,6 +41,7 @@ start_patterns = {
     "shortans_correct_choice": r"\*",
     "matching_choice": r">",
     "ordering_choice": r"~",
+    "categorization_choice": r"<",
     "feedback": r"\.\.\.",
     "correct_feedback": r"\+",
     "incorrect_feedback": r"\-",
@@ -192,6 +193,8 @@ class Choice(object):
         question_hash_digest: bytes,
         md: Markdown,
         distractor: bool = False,
+        category_str: str | None = None,
+        answer_str: str | None = None,
     ):
         self.choice_raw = text
         if shortans:
@@ -203,6 +206,8 @@ class Choice(object):
         self.feedback_raw: Optional[str] = None
         self.feedback_html_xml: Optional[str] = None
         self.distractor: bool = distractor
+        self.category_raw: str | None = category_str
+        self.answer_raw: str | None = answer_str
         # ID is based on hash of choice XML as well as question XML.  This
         # gives different IDs for identical choices in different questions.
         if shortans:
@@ -299,6 +304,9 @@ class Question(object):
         self.id = h.hexdigest()[:64]
         self.md = md
         self.n_distractors: int = 0
+        self.n_categories: int = 0
+        self.categories: List[str] = []
+        self._categories_set: Set[str] = set()
 
     def append_feedback(self, text: str):
         if self.type is not None and not self.choices:
@@ -421,6 +429,38 @@ class Question(object):
         if choice.choice_html_xml in self._choice_set:
             raise Text2qtiError("Duplicate choice for question")
         self._choice_set.add(choice.choice_html_xml)
+        self.choices.append(choice)
+
+    def append_categorization_choice(self, text: str):
+        if self.type is None:
+            self.type = "categorization_question"
+        pattern = r"(.*)\s->\s(.*)"
+        match = re.match(pattern, text)
+        if match:
+            choice_str = match.group(1)
+            category_str = match.group(2)
+            if category_str == "_":
+                distractor = True
+                self.n_distractors += 1
+            else:
+                distractor = False
+                if category_str not in self.categories:
+                    self.n_categories += 1
+                    self.categories.append(category_str)
+        choice = Choice(
+            text,
+            correct=False,
+            distractor=distractor,
+            question_hash_digest=self.hash_digest,
+            md=self.md,
+            category_str=category_str,
+            answer_str=choice_str,
+        )
+
+        if choice.answer_raw:
+            if choice.answer_raw in self._choice_set:
+                raise Text2qtiError("Duplicate choice for question")
+            self._choice_set.add(choice.answer_raw)
         self.choices.append(choice)
 
     def append_ordering_choice(self, text: str):
@@ -1285,6 +1325,16 @@ class Quiz(object):
         if not isinstance(last_question_or_delim, Question):
             raise Text2qtiError("Cannot have a choice without a question")
         last_question_or_delim.append_matching_choice(text)
+
+    def append_categorization_choice(self, text: str):
+        if self._next_question_attr:
+            raise Text2qtiError("Expected question; question title and/or points were set but not used")
+        if not self.questions_and_delims:
+            raise Text2qtiError("Cannot have a choice without a question")
+        last_question_or_delim = self.questions_and_delims[-1]
+        if not isinstance(last_question_or_delim, Question):
+            raise Text2qtiError("Cannot have a choice without a question")
+        last_question_or_delim.append_categorization_choice(text)
 
     def append_ordering_choice(self, text: str):
         if self._next_question_attr:

--- a/text2qti/xml_assessment.py
+++ b/text2qti/xml_assessment.py
@@ -6,6 +6,7 @@
 # Licensed under the BSD 3-Clause License:
 # http://opensource.org/licenses/BSD-3-Clause
 #
+import hashlib
 import re
 
 from .quiz import GroupEnd, GroupStart, Question, Quiz, TextRegion
@@ -147,6 +148,33 @@ ITEM_METADATA_MATCHING = """\
         </itemmetadata>
 """
 
+ITEM_METADATA_CATEGORIZATION = """\
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>{question_type}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>{points_possible}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>original_answer_ids</fieldlabel>
+              <fieldentry/>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>{assessment_question_identifierref}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>calculator_type</fieldlabel>
+              <fieldentry>none</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+"""
+
 ITEM_METADATA_ORDERING = """\
         <itemmetadata>
           <qtimetadata>
@@ -268,6 +296,32 @@ ITEM_PRESENTATION_MATCHING_RENDER_CHOICE = """\
               <response_label ident="{ident}">
                 <material>
                   <mattext>{answer}</mattext>
+                </material>
+              </response_label>"""
+
+ITEM_PRESENTATION_CATEGORIZATION = """\
+        <presentation>
+          <material>
+            <mattext texttype="text/html">{question_html_xml}</mattext>
+          </material>
+{choices}
+        </presentation>
+"""
+
+ITEM_PRESENTATION_CATEGORIZATION_CHOICE = """\
+          <response_lid ident="category_{ident}" rcardinality="Multiple">
+            <material>
+              <mattext texttype="text/plain">{category_raw}</mattext>
+            </material>
+            <render_choice>
+{render_choices}
+            </render_choice>
+          </response_lid>"""
+
+ITEM_PRESENTATION_CATEGORIZATION_RENDER_CHOICE = """\
+              <response_label ident="{ident}">
+                <material>
+                  <mattext texttype="text/plain">{choice_raw}</mattext>
                 </material>
               </response_label>"""
 
@@ -507,6 +561,17 @@ ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK = """\
 {varequal}
 """
 
+ITEM_RESPROCESSING_CATEGORIZATION = """\
+          <respcondition>
+            <conditionvar>
+{varequal}
+            </conditionvar>
+            <setvar action="Add" varname="SCORE">{score}</setvar>
+          </respcondition>"""
+
+ITEM_RESPROCESSING_CATEGORIZATION_VAREQUAL = """\
+              <varequal respident="category_{category_ident}">{ident}</varequal>"""
+
 ITEM_RESPROCESSING_ORDERING_START = """\
         <resprocessing>
           <outcomes>
@@ -638,6 +703,9 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
         elif question.type == "ordering_question":
             item_metadata = ITEM_METADATA_ORDERING
             original_answer_ids = ",".join(f"text2qti_choice_{c.id}" for c in question.choices)
+        elif question.type == "categorization_question":
+            item_metadata = ITEM_METADATA_CATEGORIZATION
+            original_answer_ids = ",".join(f"text2qti_choice_{c.id}" for c in question.choices)
         else:
             raise ValueError
         xml.append(
@@ -714,6 +782,35 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
 
             choices = "\n".join(choices_list)
             xml.append(ITEM_PRESENTATION_MATCHING.format(question_html_xml=question.question_html_xml, choices=choices))
+        elif question.type == "categorization_question":
+            render_choices_list = []
+            dist_count = 0
+            for c in question.choices:
+                if c.distractor:
+                    dist_count += 1
+                ident = f"text2qti_choice_{c.id}"
+
+                render_choices_list.append(
+                    ITEM_PRESENTATION_CATEGORIZATION_RENDER_CHOICE.format(ident=ident, choice_raw=c.answer_raw)
+                )
+
+            render_choices = "\n".join(render_choices_list)
+            choices_list = []
+            for category_str in question.categories:
+                category_id = hashlib.blake2b(category_str.encode("utf8")).hexdigest()[:64]
+                choices_list.append(
+                    ITEM_PRESENTATION_CATEGORIZATION_CHOICE.format(
+                        ident=f"{category_id}",
+                        render_choices=render_choices,
+                        category_raw=category_str,
+                    )
+                )
+
+            choices = "\n".join(choices_list)
+            xml.append(
+                ITEM_PRESENTATION_CATEGORIZATION.format(question_html_xml=question.question_html_xml, choices=choices)
+            )
+
         elif question.type == "ordering_question":
             render_choices_list = []
             choices_list = []
@@ -892,6 +989,50 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
             #     resprocessing.append(ITEM_RESPROCESSING_MULTANS_INCORRECT_FEEDBACK)
             resprocessing.append(ITEM_RESPROCESSING_END)
             xml.extend(resprocessing)
+        elif question.type == "categorization_question":
+            resprocessing = []
+            resprocessing.append(ITEM_RESPROCESSING_START)
+            # TODO: Later.
+            # if question.feedback_raw is not None:
+            #    resprocessing.append(ITEM_RESPROCESSING_MULTANS_GENERAL_FEEDBACK)
+
+            # for choice in question.choices:
+            #     if choice.feedback_raw is not None:
+            #         resprocessing.append(ITEM_RESPROCESSING_MULTANS_CHOICE_FEEDBACK.format(ident=f'text2qti_choice_{choice.id}'))
+
+            varequal = []
+            score_per_question = 100 / question.n_categories
+            score_per_question = round(score_per_question, 2)
+
+            for category in question.categories:
+                # Get hash of current category.
+                category_id = hashlib.blake2b(category.encode("utf8")).hexdigest()[:64]
+                varequal_category = []
+                for choice in question.choices:
+                    if choice.category_raw == category:
+                        varequal_category.append(
+                            ITEM_RESPROCESSING_CATEGORIZATION_VAREQUAL.format(
+                                category_ident=f"{category_id}", ident=f"text2qti_choice_{choice.id}"
+                            )
+                        )
+                varequal.append(
+                    ITEM_RESPROCESSING_CATEGORIZATION.format(
+                        varequal="\n".join(varequal_category), score=score_per_question
+                    )
+                )
+            if question.correct_feedback_raw is not None:
+                resprocessing.append(
+                    ITEM_RESPROCESSING_MULTANS_SET_CORRECT_WITH_FEEDBACK.format(varequal="\n".join(varequal))
+                )
+            else:
+                resprocessing.append(
+                    ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK.format(varequal="\n".join(varequal))
+                )
+            # if question.incorrect_feedback_raw is not None:
+            #     resprocessing.append(ITEM_RESPROCESSING_MULTANS_INCORRECT_FEEDBACK)
+            resprocessing.append(ITEM_RESPROCESSING_END)
+            xml.extend(resprocessing)
+
         elif question.type == "ordering_question":
             resprocessing = []
             # TODO: Later.

--- a/text2qti/xml_assessment.py
+++ b/text2qti/xml_assessment.py
@@ -6,7 +6,7 @@
 # Licensed under the BSD 3-Clause License:
 # http://opensource.org/licenses/BSD-3-Clause
 #
-
+import re
 
 from .quiz import Quiz, Question, GroupStart, GroupEnd, TextRegion
 
@@ -112,6 +112,38 @@ ITEM_METADATA_ESSAY = ITEM_METADATA_MCTF_SHORTANS_MULTANS_NUM.replace('{original
 
 ITEM_METADATA_UPLOAD = ITEM_METADATA_ESSAY
 
+
+ITEM_METADATA_MATCHING = '''\
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>{question_type}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>{points_possible}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>original_answer_ids</fieldlabel>
+              <fieldentry>{original_answer_ids}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>{assessment_question_identifierref}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>calculator_type</fieldlabel>
+              <fieldentry>none</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>scoring_algorithm</fieldlabel>
+              <fieldentry>DeepEquals</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+'''
+
 ITEM_PRESENTATION_MCTF = '''\
         <presentation>
           <material>
@@ -182,6 +214,32 @@ ITEM_PRESENTATION_NUM = '''\
           </response_str>
         </presentation>
 '''
+
+ITEM_PRESENTATION_MATCHING = '''\
+        <presentation>
+          <material>
+            <mattext texttype="text/html">{question_html_xml}</mattext>
+          </material>
+{choices}
+        </presentation>
+'''
+
+ITEM_PRESENTATION_MATCHING_CHOICE = '''\
+          <response_lid ident="response_{ident}">
+            <material>
+              <mattext texttype="text/html">{choice_html_xml}</mattext>
+            </material>
+            <render_choice>
+{render_choices}
+            </render_choice>
+          </response_lid>'''
+
+ITEM_PRESENTATION_MATCHING_RENDER_CHOICE = '''\
+              <response_label ident="{ident}">
+                <material>
+                  <mattext>{answer}</mattext>
+                </material>
+              </response_label>'''
 
 
 ITEM_RESPROCESSING_START = '''\
@@ -377,6 +435,18 @@ ITEM_RESPROCESSING_ESSAY = '''\
           </respcondition>
 '''
 
+ITEM_RESPROCESSING_MATCHING = '''\
+          <respcondition>
+            <conditionvar>
+              <varequal respident="response_{ident}">{ident}</varequal>
+            </conditionvar>
+            <setvar action="Add" varname="SCORE">33.33</setvar>
+          </respcondition>'''
+
+ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK = '''\
+{varequal}
+'''
+
 
 
 ITEM_RESPROCESSING_END = '''\
@@ -458,7 +528,8 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
                                      question_title=question.title_xml))
 
         if question.type in ('true_false_question', 'multiple_choice_question',
-                             'short_answer_question', 'multiple_answers_question'):
+                             'short_answer_question', 'multiple_answers_question',
+                             ):
             item_metadata = ITEM_METADATA_MCTF_SHORTANS_MULTANS_NUM
             original_answer_ids = ','.join(f'text2qti_choice_{c.id}' for c in question.choices)
         elif question.type == 'numerical_question':
@@ -470,6 +541,9 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
         elif question.type == 'file_upload_question':
             item_metadata = ITEM_METADATA_UPLOAD
             original_answer_ids = f'text2qti_upload_{question.id}'
+        elif question.type == 'matching_question':
+            item_metadata = ITEM_METADATA_MATCHING
+            original_answer_ids = ','.join(f'text2qti_choice_{c.id}' for c in question.choices)
         else:
             raise ValueError
         xml.append(item_metadata.format(question_type=question.type,
@@ -497,6 +571,32 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
             xml.append(ITEM_PRESENTATION_ESSAY.format(question_html_xml=question.question_html_xml))
         elif question.type == 'file_upload_question':
             xml.append(ITEM_PRESENTATION_UPLOAD.format(question_html_xml=question.question_html_xml))
+        elif question.type == 'matching_question':
+            render_choices_list = []
+            for c in question.choices:
+                matching_pattern = r"(.*)\s->\s(.*)"
+                match = re.match(matching_pattern, c.choice_raw)
+                if match:
+                    question_str = match.group(1)
+                    answer_str = match.group(2)
+                else:
+                    raise ValueError("Matching question not formatted correctly")
+                render_choices_list.append(ITEM_PRESENTATION_MATCHING_RENDER_CHOICE.format(ident=f'text2qti_choice_{c.id}', answer=answer_str, choice_html_xml=question_str))
+
+            render_choices = "\n".join(render_choices_list)
+            choices_list = []
+            for c in question.choices:
+                matching_pattern = r"(.*)\s->\s(.*)"
+                match = re.match(matching_pattern, c.choice_raw)
+                if match:
+                    question_str = match.group(1)
+                    answer_str = match.group(2)
+                else:
+                    raise ValueError("Matching question not formatted correctly")
+                choices_list.append(ITEM_PRESENTATION_MATCHING_CHOICE.format(ident=f'text2qti_choice_{c.id}', render_choices=render_choices, choice_html_xml=question_str))
+
+            choices = "\n".join(choices_list)
+            xml.append(ITEM_PRESENTATION_MATCHING.format(question_html_xml=question.question_html_xml, choices=choices))
         else:
             raise ValueError
 
@@ -595,6 +695,28 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
             if question.feedback_raw is not None:
                 xml.append(ITEM_RESPROCESSING_UPLOAD_GENERAL_FEEDBACK)
             xml.append(ITEM_RESPROCESSING_END)
+        elif question.type == 'matching_question':
+            resprocessing = []
+            resprocessing.append(ITEM_RESPROCESSING_START)
+             # TODO: Later.
+            #if question.feedback_raw is not None:
+            #    resprocessing.append(ITEM_RESPROCESSING_MULTANS_GENERAL_FEEDBACK)
+
+            # for choice in question.choices:
+            #     if choice.feedback_raw is not None:
+            #         resprocessing.append(ITEM_RESPROCESSING_MULTANS_CHOICE_FEEDBACK.format(ident=f'text2qti_choice_{choice.id}'))
+
+            varequal = []
+            for choice in question.choices:
+                  varequal.append(ITEM_RESPROCESSING_MATCHING.format(ident=f'text2qti_choice_{choice.id}'))
+            if question.correct_feedback_raw is not None:
+               resprocessing.append(ITEM_RESPROCESSING_MULTANS_SET_CORRECT_WITH_FEEDBACK.format(varequal='\n'.join(varequal)))
+            else:
+                resprocessing.append(ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK.format(varequal='\n'.join(varequal)))
+            # if question.incorrect_feedback_raw is not None:
+            #     resprocessing.append(ITEM_RESPROCESSING_MULTANS_INCORRECT_FEEDBACK)
+            resprocessing.append(ITEM_RESPROCESSING_END)
+            xml.extend(resprocessing)
         else:
             raise ValueError
 

--- a/text2qti/xml_assessment.py
+++ b/text2qti/xml_assessment.py
@@ -496,7 +496,7 @@ ITEM_RESPROCESSING_MATCHING = """\
             <conditionvar>
               <varequal respident="response_{ident}">{ident}</varequal>
             </conditionvar>
-            <setvar action="Add" varname="SCORE">33.33</setvar>
+            <setvar action="Add" varname="SCORE">{score}</setvar>
           </respcondition>"""
 
 ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK = """\
@@ -854,8 +854,13 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
             #         resprocessing.append(ITEM_RESPROCESSING_MULTANS_CHOICE_FEEDBACK.format(ident=f'text2qti_choice_{choice.id}'))
 
             varequal = []
+            n_choices = len(question.choices)
+            score_per_question = 100 / n_choices
+            score_per_question = round(score_per_question, 2)
             for choice in question.choices:
-                varequal.append(ITEM_RESPROCESSING_MATCHING.format(ident=f"text2qti_choice_{choice.id}"))
+                varequal.append(
+                    ITEM_RESPROCESSING_MATCHING.format(ident=f"text2qti_choice_{choice.id}", score=score_per_question)
+                )
             if question.correct_feedback_raw is not None:
                 resprocessing.append(
                     ITEM_RESPROCESSING_MULTANS_SET_CORRECT_WITH_FEEDBACK.format(varequal="\n".join(varequal))

--- a/text2qti/xml_assessment.py
+++ b/text2qti/xml_assessment.py
@@ -17,7 +17,7 @@ BEFORE_ITEMS = """\
     <qtimetadata>
       <qtimetadatafield>
         <fieldlabel>cc_maxattempts</fieldlabel>
-        <fieldentry>1</fieldentry>
+        <fieldentry>{allowed_attempts}</fieldentry>
       </qtimetadatafield>
     </qtimetadata>
     <section ident="root_section">
@@ -574,7 +574,11 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
     Generate assessment XML from Quiz.
     """
     xml = []
-    xml.append(BEFORE_ITEMS.format(assessment_identifier=assessment_identifier, title=title_xml))
+    xml.append(
+        BEFORE_ITEMS.format(
+            assessment_identifier=assessment_identifier, title=title_xml, allowed_attempts=quiz.allowed_attempts_xml
+        )
+    )
     for question_or_delim in quiz.questions_and_delims:
         if isinstance(question_or_delim, TextRegion):
             xml.append(

--- a/text2qti/xml_assessment.py
+++ b/text2qti/xml_assessment.py
@@ -270,7 +270,7 @@ ITEM_PRESENTATION_MATCHING_RENDER_CHOICE = """\
 ITEM_PRESENTATION_ORDERING = """\
         <presentation>
           <material>
-            <mattext texttype="text/html">&lt;p&gt;Test stem&lt;/p&gt;</mattext>
+            <mattext texttype="text/html">{question_html_xml}</mattext>
           </material>
           <response_lid ident="response1" rcardinality="Ordered">
             <render_extension>

--- a/text2qti/xml_assessment.py
+++ b/text2qti/xml_assessment.py
@@ -103,6 +103,10 @@ ITEM_METADATA_MCTF_SHORTANS_MULTANS_NUM = """\
               <fieldlabel>assessment_question_identifierref</fieldlabel>
               <fieldentry>{assessment_question_identifierref}</fieldentry>
             </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>calculator_type</fieldlabel>
+              <fieldentry>{calculator_type}</fieldentry>
+            </qtimetadatafield>
           </qtimetadata>
         </itemmetadata>
 """
@@ -642,6 +646,7 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
                 points_possible=question.points_possible,
                 original_answer_ids=original_answer_ids,
                 assessment_question_identifierref=f"text2qti_question_ref_{question.id}",
+                calculator_type=question.calculator_type,
             )
         )
 

--- a/text2qti/xml_assessment.py
+++ b/text2qti/xml_assessment.py
@@ -143,6 +143,33 @@ ITEM_METADATA_MATCHING = """\
         </itemmetadata>
 """
 
+ITEM_METADATA_ORDERING = """\
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>{question_type}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>{points_possible}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>original_answer_ids</fieldlabel>
+              <fieldentry>{original_answer_ids}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>{assessment_question_identifierref}</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>calculator_type</fieldlabel>
+              <fieldentry>none</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+"""
+
 ITEM_PRESENTATION_MCTF = """\
         <presentation>
           <material>
@@ -239,6 +266,36 @@ ITEM_PRESENTATION_MATCHING_RENDER_CHOICE = """\
                   <mattext>{answer}</mattext>
                 </material>
               </response_label>"""
+
+ITEM_PRESENTATION_ORDERING = """\
+        <presentation>
+          <material>
+            <mattext texttype="text/html">&lt;p&gt;Test stem&lt;/p&gt;</mattext>
+          </material>
+          <response_lid ident="response1" rcardinality="Ordered">
+            <render_extension>
+              <material position="top">
+                <mattext/>
+              </material>
+              <ims_render_object shuffle="No">
+                <flow_label>
+{choices}
+                </flow_label>
+              </ims_render_object>
+              <material position="bottom">
+                <mattext/>
+              </material>
+            </render_extension>
+          </response_lid>
+        </presentation>
+"""
+
+ITEM_PRESENTATION_ORDERING_CHOICE = """\
+                  <response_label ident="{ident}">
+                    <material>
+                      <mattext texttype="text/html">{choice_html_xml}</mattext>
+                    </material>
+                  </response_label>"""
 
 
 ITEM_RESPROCESSING_START = """\
@@ -446,6 +503,25 @@ ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK = """\
 {varequal}
 """
 
+ITEM_RESPROCESSING_ORDERING_START = """\
+        <resprocessing>
+          <outcomes>
+            <decvar defaultval="1" varname="ORDERSCORE" vartype="Integer"/>
+          </outcomes>
+          <respcondition continue="No">
+            <conditionvar>
+{choices}
+            </conditionvar>
+            <setvar action="Set" varname="SCORE">100</setvar>
+          </respcondition>
+"""
+
+ITEM_RESPROCESSING_ORDERING = """\
+              <varequal respident="response1">{ident}</varequal>"""
+
+ITEM_RESPROCESSING_ORDERING_SET_CORRECT_NO_FEEDBACK = """\
+{varequal}"""
+
 
 ITEM_RESPROCESSING_END = """\
         </resprocessing>
@@ -551,6 +627,9 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
         elif question.type == "matching_question":
             item_metadata = ITEM_METADATA_MATCHING
             original_answer_ids = ",".join(f"text2qti_choice_{c.id}" for c in question.choices)
+        elif question.type == "ordering_question":
+            item_metadata = ITEM_METADATA_ORDERING
+            original_answer_ids = ",".join(f"text2qti_choice_{c.id}" for c in question.choices)
         else:
             raise ValueError
         xml.append(
@@ -618,6 +697,19 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
 
             choices = "\n".join(choices_list)
             xml.append(ITEM_PRESENTATION_MATCHING.format(question_html_xml=question.question_html_xml, choices=choices))
+        elif question.type == "ordering_question":
+            render_choices_list = []
+            choices_list = []
+            for c in question.choices:
+                choices_list.append(
+                    ITEM_PRESENTATION_ORDERING_CHOICE.format(
+                        ident=f"text2qti_choice_{c.id}", choice_html_xml=c.choice_html_xml
+                    )
+                )
+
+            choices = "\n".join(choices_list)
+            xml.append(ITEM_PRESENTATION_ORDERING.format(question_html_xml=question.question_html_xml, choices=choices))
+
         else:
             raise ValueError
 
@@ -771,6 +863,31 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
             else:
                 resprocessing.append(
                     ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK.format(varequal="\n".join(varequal))
+                )
+            # if question.incorrect_feedback_raw is not None:
+            #     resprocessing.append(ITEM_RESPROCESSING_MULTANS_INCORRECT_FEEDBACK)
+            resprocessing.append(ITEM_RESPROCESSING_END)
+            xml.extend(resprocessing)
+        elif question.type == "ordering_question":
+            resprocessing = []
+            # TODO: Later.
+            # if question.feedback_raw is not None:
+            #    resprocessing.append(ITEM_RESPROCESSING_MULTANS_GENERAL_FEEDBACK)
+
+            # for choice in question.choices:
+            #     if choice.feedback_raw is not None:
+            #         resprocessing.append(ITEM_RESPROCESSING_MULTANS_CHOICE_FEEDBACK.format(ident=f'text2qti_choice_{choice.id}'))
+
+            varequal = []
+            for choice in question.choices:
+                varequal.append(ITEM_RESPROCESSING_ORDERING.format(ident=f"text2qti_choice_{choice.id}"))
+            if question.correct_feedback_raw is not None:
+                raise NotImplementedError
+            else:
+                resprocessing.append(
+                    ITEM_RESPROCESSING_ORDERING_START.format(
+                        choices=ITEM_RESPROCESSING_ORDERING_SET_CORRECT_NO_FEEDBACK.format(varequal="\n".join(varequal))
+                    )
                 )
             # if question.incorrect_feedback_raw is not None:
             #     resprocessing.append(ITEM_RESPROCESSING_MULTANS_INCORRECT_FEEDBACK)

--- a/text2qti/xml_assessment.py
+++ b/text2qti/xml_assessment.py
@@ -665,6 +665,7 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
             xml.append(ITEM_PRESENTATION_UPLOAD.format(question_html_xml=question.question_html_xml))
         elif question.type == "matching_question":
             render_choices_list = []
+            dist_count = 0
             for c in question.choices:
                 matching_pattern = r"(.*)\s->\s(.*)"
                 match = re.match(matching_pattern, c.choice_raw)
@@ -673,9 +674,15 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
                     answer_str = match.group(2)
                 else:
                     raise ValueError("Matching question not formatted correctly")
+                if c.distractor:
+                    ident = f"distractor_{dist_count}"
+                    dist_count += 1
+                else:
+                    ident = f"text2qti_choice_{c.id}"
+
                 render_choices_list.append(
                     ITEM_PRESENTATION_MATCHING_RENDER_CHOICE.format(
-                        ident=f"text2qti_choice_{c.id}", answer=answer_str, choice_html_xml=question_str
+                        ident=ident, answer=answer_str, choice_html_xml=question_str
                     )
                 )
 
@@ -689,11 +696,12 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
                     answer_str = match.group(2)
                 else:
                     raise ValueError("Matching question not formatted correctly")
-                choices_list.append(
-                    ITEM_PRESENTATION_MATCHING_CHOICE.format(
-                        ident=f"text2qti_choice_{c.id}", render_choices=render_choices, choice_html_xml=question_str
+                if not c.distractor:
+                    choices_list.append(
+                        ITEM_PRESENTATION_MATCHING_CHOICE.format(
+                            ident=f"text2qti_choice_{c.id}", render_choices=render_choices, choice_html_xml=question_str
+                        )
                     )
-                )
 
             choices = "\n".join(choices_list)
             xml.append(ITEM_PRESENTATION_MATCHING.format(question_html_xml=question.question_html_xml, choices=choices))
@@ -853,11 +861,13 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
             #     if choice.feedback_raw is not None:
             #         resprocessing.append(ITEM_RESPROCESSING_MULTANS_CHOICE_FEEDBACK.format(ident=f'text2qti_choice_{choice.id}'))
 
+            non_distract_choices = [c for c in question.choices if not c.distractor]
             varequal = []
-            n_choices = len(question.choices)
+            n_choices = len(non_distract_choices)
             score_per_question = 100 / n_choices
             score_per_question = round(score_per_question, 2)
-            for choice in question.choices:
+
+            for choice in non_distract_choices:
                 varequal.append(
                     ITEM_RESPROCESSING_MATCHING.format(ident=f"text2qti_choice_{choice.id}", score=score_per_question)
                 )

--- a/text2qti/xml_assessment.py
+++ b/text2qti/xml_assessment.py
@@ -8,10 +8,9 @@
 #
 import re
 
-from .quiz import Quiz, Question, GroupStart, GroupEnd, TextRegion
+from .quiz import GroupEnd, GroupStart, Question, Quiz, TextRegion
 
-
-BEFORE_ITEMS = '''\
+BEFORE_ITEMS = """\
 <?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
   <assessment ident="{assessment_identifier}" title="{title}">
@@ -22,15 +21,15 @@ BEFORE_ITEMS = '''\
       </qtimetadatafield>
     </qtimetadata>
     <section ident="root_section">
-'''
+"""
 
-AFTER_ITEMS = '''\
+AFTER_ITEMS = """\
     </section>
   </assessment>
 </questestinterop>
-'''
+"""
 
-GROUP_START = '''\
+GROUP_START = """\
     <section ident="{ident}" title="{group_title}">
       <selection_ordering>
         <selection>
@@ -40,13 +39,13 @@ GROUP_START = '''\
           </selection_extension>
         </selection>
       </selection_ordering>
-'''
+"""
 
-GROUP_END = '''\
+GROUP_END = """\
     </section>
-'''
+"""
 
-TEXT = '''\
+TEXT = """\
       <item ident="{ident}" title="{text_title_xml}">
         <itemmetadata>
           <qtimetadata>
@@ -74,18 +73,18 @@ TEXT = '''\
           </material>
         </presentation>
       </item>
-'''
+"""
 
-START_ITEM = '''\
+START_ITEM = """\
       <item ident="{question_identifier}" title="{question_title}">
-'''
+"""
 
-END_ITEM = '''\
+END_ITEM = """\
       </item>
-'''
+"""
 
 
-ITEM_METADATA_MCTF_SHORTANS_MULTANS_NUM = '''\
+ITEM_METADATA_MCTF_SHORTANS_MULTANS_NUM = """\
         <itemmetadata>
           <qtimetadata>
             <qtimetadatafield>
@@ -106,14 +105,14 @@ ITEM_METADATA_MCTF_SHORTANS_MULTANS_NUM = '''\
             </qtimetadatafield>
           </qtimetadata>
         </itemmetadata>
-'''
+"""
 
-ITEM_METADATA_ESSAY = ITEM_METADATA_MCTF_SHORTANS_MULTANS_NUM.replace('{original_answer_ids}', '')
+ITEM_METADATA_ESSAY = ITEM_METADATA_MCTF_SHORTANS_MULTANS_NUM.replace("{original_answer_ids}", "")
 
 ITEM_METADATA_UPLOAD = ITEM_METADATA_ESSAY
 
 
-ITEM_METADATA_MATCHING = '''\
+ITEM_METADATA_MATCHING = """\
         <itemmetadata>
           <qtimetadata>
             <qtimetadatafield>
@@ -142,9 +141,9 @@ ITEM_METADATA_MATCHING = '''\
             </qtimetadatafield>
           </qtimetadata>
         </itemmetadata>
-'''
+"""
 
-ITEM_PRESENTATION_MCTF = '''\
+ITEM_PRESENTATION_MCTF = """\
         <presentation>
           <material>
             <mattext texttype="text/html">{question_html_xml}</mattext>
@@ -155,20 +154,20 @@ ITEM_PRESENTATION_MCTF = '''\
             </render_choice>
           </response_lid>
         </presentation>
-'''
+"""
 
-ITEM_PRESENTATION_MCTF_CHOICE = '''\
+ITEM_PRESENTATION_MCTF_CHOICE = """\
               <response_label ident="{ident}">
                 <material>
                   <mattext texttype="text/html">{choice_html_xml}</mattext>
                 </material>
-              </response_label>'''
+              </response_label>"""
 
-ITEM_PRESENTATION_MULTANS = ITEM_PRESENTATION_MCTF.replace('Single', 'Multiple')
+ITEM_PRESENTATION_MULTANS = ITEM_PRESENTATION_MCTF.replace("Single", "Multiple")
 
 ITEM_PRESENTATION_MULTANS_CHOICE = ITEM_PRESENTATION_MCTF_CHOICE
 
-ITEM_PRESENTATION_SHORTANS = '''\
+ITEM_PRESENTATION_SHORTANS = """\
         <presentation>
           <material>
             <mattext texttype="text/html">{question_html_xml}</mattext>
@@ -179,9 +178,9 @@ ITEM_PRESENTATION_SHORTANS = '''\
             </render_fib>
           </response_str>
         </presentation>
-'''
+"""
 
-ITEM_PRESENTATION_ESSAY = '''\
+ITEM_PRESENTATION_ESSAY = """\
         <presentation>
           <material>
             <mattext texttype="text/html">{question_html_xml}</mattext>
@@ -192,17 +191,17 @@ ITEM_PRESENTATION_ESSAY = '''\
             </render_fib>
           </response_str>
         </presentation>
-'''
+"""
 
-ITEM_PRESENTATION_UPLOAD = '''\
+ITEM_PRESENTATION_UPLOAD = """\
         <presentation>
           <material>
             <mattext texttype="text/html">{question_html_xml}</mattext>
           </material>
         </presentation>
-'''
+"""
 
-ITEM_PRESENTATION_NUM = '''\
+ITEM_PRESENTATION_NUM = """\
         <presentation>
           <material>
             <mattext texttype="text/html">{question_html_xml}</mattext>
@@ -213,18 +212,18 @@ ITEM_PRESENTATION_NUM = '''\
             </render_fib>
           </response_str>
         </presentation>
-'''
+"""
 
-ITEM_PRESENTATION_MATCHING = '''\
+ITEM_PRESENTATION_MATCHING = """\
         <presentation>
           <material>
             <mattext texttype="text/html">{question_html_xml}</mattext>
           </material>
 {choices}
         </presentation>
-'''
+"""
 
-ITEM_PRESENTATION_MATCHING_CHOICE = '''\
+ITEM_PRESENTATION_MATCHING_CHOICE = """\
           <response_lid ident="response_{ident}">
             <material>
               <mattext texttype="text/html">{choice_html_xml}</mattext>
@@ -232,42 +231,42 @@ ITEM_PRESENTATION_MATCHING_CHOICE = '''\
             <render_choice>
 {render_choices}
             </render_choice>
-          </response_lid>'''
+          </response_lid>"""
 
-ITEM_PRESENTATION_MATCHING_RENDER_CHOICE = '''\
+ITEM_PRESENTATION_MATCHING_RENDER_CHOICE = """\
               <response_label ident="{ident}">
                 <material>
                   <mattext>{answer}</mattext>
                 </material>
-              </response_label>'''
+              </response_label>"""
 
 
-ITEM_RESPROCESSING_START = '''\
+ITEM_RESPROCESSING_START = """\
         <resprocessing>
           <outcomes>
             <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
           </outcomes>
-'''
+"""
 
-ITEM_RESPROCESSING_MCTF_GENERAL_FEEDBACK = '''\
+ITEM_RESPROCESSING_MCTF_GENERAL_FEEDBACK = """\
           <respcondition continue="Yes">
             <conditionvar>
               <other/>
             </conditionvar>
             <displayfeedback feedbacktype="Response" linkrefid="general_fb"/>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_MCTF_CHOICE_FEEDBACK = '''\
+ITEM_RESPROCESSING_MCTF_CHOICE_FEEDBACK = """\
           <respcondition continue="Yes">
             <conditionvar>
               <varequal respident="response1">{ident}</varequal>
             </conditionvar>
             <displayfeedback feedbacktype="Response" linkrefid="{ident}_fb"/>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_MCTF_SET_CORRECT_WITH_FEEDBACK = '''\
+ITEM_RESPROCESSING_MCTF_SET_CORRECT_WITH_FEEDBACK = """\
           <respcondition continue="No">
             <conditionvar>
               <varequal respident="response1">{ident}</varequal>
@@ -275,38 +274,38 @@ ITEM_RESPROCESSING_MCTF_SET_CORRECT_WITH_FEEDBACK = '''\
             <setvar action="Set" varname="SCORE">100</setvar>
             <displayfeedback feedbacktype="Response" linkrefid="correct_fb"/>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_MCTF_SET_CORRECT_NO_FEEDBACK = '''\
+ITEM_RESPROCESSING_MCTF_SET_CORRECT_NO_FEEDBACK = """\
           <respcondition continue="No">
             <conditionvar>
               <varequal respident="response1">{ident}</varequal>
             </conditionvar>
             <setvar action="Set" varname="SCORE">100</setvar>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_MCTF_INCORRECT_FEEDBACK = '''\
+ITEM_RESPROCESSING_MCTF_INCORRECT_FEEDBACK = """\
           <respcondition continue="Yes">
             <conditionvar>
               <other/>
             </conditionvar>
             <displayfeedback feedbacktype="Response" linkrefid="general_incorrect_fb"/>
           </respcondition>
-'''
+"""
 
 ITEM_RESPROCESSING_SHORTANS_GENERAL_FEEDBACK = ITEM_RESPROCESSING_MCTF_GENERAL_FEEDBACK
 
-ITEM_RESPROCESSING_SHORTANS_CHOICE_FEEDBACK = '''\
+ITEM_RESPROCESSING_SHORTANS_CHOICE_FEEDBACK = """\
           <respcondition continue="Yes">
             <conditionvar>
               <varequal respident="response1">{answer_xml}</varequal>
             </conditionvar>
             <displayfeedback feedbacktype="Response" linkrefid="{ident}_fb"/>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_WITH_FEEDBACK = '''\
+ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_WITH_FEEDBACK = """\
           <respcondition continue="No">
             <conditionvar>
 {varequal}
@@ -314,19 +313,19 @@ ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_WITH_FEEDBACK = '''\
             <setvar action="Set" varname="SCORE">100</setvar>
             <displayfeedback feedbacktype="Response" linkrefid="correct_fb"/>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_NO_FEEDBACK = '''\
+ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_NO_FEEDBACK = """\
           <respcondition continue="No">
             <conditionvar>
 {varequal}
             </conditionvar>
             <setvar action="Set" varname="SCORE">100</setvar>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_VAREQUAL = '''\
-              <varequal respident="response1">{answer_xml}</varequal>'''
+ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_VAREQUAL = """\
+              <varequal respident="response1">{answer_xml}</varequal>"""
 
 ITEM_RESPROCESSING_SHORTANS_INCORRECT_FEEDBACK = ITEM_RESPROCESSING_MCTF_INCORRECT_FEEDBACK
 
@@ -334,7 +333,7 @@ ITEM_RESPROCESSING_MULTANS_GENERAL_FEEDBACK = ITEM_RESPROCESSING_MCTF_GENERAL_FE
 
 ITEM_RESPROCESSING_MULTANS_CHOICE_FEEDBACK = ITEM_RESPROCESSING_MCTF_CHOICE_FEEDBACK
 
-ITEM_RESPROCESSING_MULTANS_SET_CORRECT_WITH_FEEDBACK = '''\
+ITEM_RESPROCESSING_MULTANS_SET_CORRECT_WITH_FEEDBACK = """\
           <respcondition continue="No">
             <conditionvar>
               <and>
@@ -344,9 +343,9 @@ ITEM_RESPROCESSING_MULTANS_SET_CORRECT_WITH_FEEDBACK = '''\
             <setvar action="Set" varname="SCORE">100</setvar>
             <displayfeedback feedbacktype="Response" linkrefid="correct_fb"/>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_MULTANS_SET_CORRECT_NO_FEEDBACK = '''\
+ITEM_RESPROCESSING_MULTANS_SET_CORRECT_NO_FEEDBACK = """\
           <respcondition continue="No">
             <conditionvar>
               <and>
@@ -355,15 +354,15 @@ ITEM_RESPROCESSING_MULTANS_SET_CORRECT_NO_FEEDBACK = '''\
             </conditionvar>
             <setvar action="Set" varname="SCORE">100</setvar>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_MULTANS_SET_CORRECT_VAREQUAL_CORRECT = '''\
-                <varequal respident="response1">{ident}</varequal>'''
+ITEM_RESPROCESSING_MULTANS_SET_CORRECT_VAREQUAL_CORRECT = """\
+                <varequal respident="response1">{ident}</varequal>"""
 
-ITEM_RESPROCESSING_MULTANS_SET_CORRECT_VAREQUAL_INCORRECT = '''\
+ITEM_RESPROCESSING_MULTANS_SET_CORRECT_VAREQUAL_INCORRECT = """\
                 <not>
                   <varequal respident="response1">{ident}</varequal>
-                </not>'''
+                </not>"""
 
 ITEM_RESPROCESSING_MULTANS_INCORRECT_FEEDBACK = ITEM_RESPROCESSING_MCTF_INCORRECT_FEEDBACK
 
@@ -373,7 +372,7 @@ ITEM_RESPROCESSING_UPLOAD_GENERAL_FEEDBACK = ITEM_RESPROCESSING_MCTF_GENERAL_FEE
 
 ITEM_RESPROCESSING_NUM_GENERAL_FEEDBACK = ITEM_RESPROCESSING_MCTF_GENERAL_FEEDBACK
 
-ITEM_RESPROCESSING_NUM_RANGE_SET_CORRECT_WITH_FEEDBACK = '''\
+ITEM_RESPROCESSING_NUM_RANGE_SET_CORRECT_WITH_FEEDBACK = """\
           <respcondition continue="No">
             <conditionvar>
               <vargte respident="response1">{num_min}</vargte>
@@ -382,9 +381,9 @@ ITEM_RESPROCESSING_NUM_RANGE_SET_CORRECT_WITH_FEEDBACK = '''\
             <setvar action="Set" varname="SCORE">100</setvar>
             <displayfeedback feedbacktype="Response" linkrefid="correct_fb"/>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_NUM_RANGE_SET_CORRECT_NO_FEEDBACK = '''\
+ITEM_RESPROCESSING_NUM_RANGE_SET_CORRECT_NO_FEEDBACK = """\
           <respcondition continue="No">
             <conditionvar>
               <vargte respident="response1">{num_min}</vargte>
@@ -392,9 +391,9 @@ ITEM_RESPROCESSING_NUM_RANGE_SET_CORRECT_NO_FEEDBACK = '''\
             </conditionvar>
             <setvar action="Set" varname="SCORE">100</setvar>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_NUM_EXACT_SET_CORRECT_WITH_FEEDBACK = '''\
+ITEM_RESPROCESSING_NUM_EXACT_SET_CORRECT_WITH_FEEDBACK = """\
           <respcondition continue="No">
             <conditionvar>
               <or>
@@ -408,9 +407,9 @@ ITEM_RESPROCESSING_NUM_EXACT_SET_CORRECT_WITH_FEEDBACK = '''\
             <setvar action="Set" varname="SCORE">100</setvar>
             <displayfeedback feedbacktype="Response" linkrefid="correct_fb"/>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_NUM_EXACT_SET_CORRECT_NO_FEEDBACK = '''\
+ITEM_RESPROCESSING_NUM_EXACT_SET_CORRECT_NO_FEEDBACK = """\
           <respcondition continue="No">
             <conditionvar>
               <or>
@@ -423,38 +422,37 @@ ITEM_RESPROCESSING_NUM_EXACT_SET_CORRECT_NO_FEEDBACK = '''\
             </conditionvar>
             <setvar action="Set" varname="SCORE">100</setvar>
           </respcondition>
-'''
+"""
 
 ITEM_RESPROCESSING_NUM_INCORRECT_FEEDBACK = ITEM_RESPROCESSING_MCTF_INCORRECT_FEEDBACK
 
-ITEM_RESPROCESSING_ESSAY = '''\
+ITEM_RESPROCESSING_ESSAY = """\
           <respcondition continue="No">
             <conditionvar>
               <other/>
             </conditionvar>
           </respcondition>
-'''
+"""
 
-ITEM_RESPROCESSING_MATCHING = '''\
+ITEM_RESPROCESSING_MATCHING = """\
           <respcondition>
             <conditionvar>
               <varequal respident="response_{ident}">{ident}</varequal>
             </conditionvar>
             <setvar action="Add" varname="SCORE">33.33</setvar>
-          </respcondition>'''
+          </respcondition>"""
 
-ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK = '''\
+ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK = """\
 {varequal}
-'''
+"""
 
 
-
-ITEM_RESPROCESSING_END = '''\
+ITEM_RESPROCESSING_END = """\
         </resprocessing>
-'''
+"""
 
 
-ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_GENERAL = '''\
+ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_GENERAL = """\
         <itemfeedback ident="general_fb">
           <flow_mat>
             <material>
@@ -462,9 +460,9 @@ ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_GENERAL = '''\
             </material>
           </flow_mat>
         </itemfeedback>
-'''
+"""
 
-ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_CORRECT = '''\
+ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_CORRECT = """\
         <itemfeedback ident="correct_fb">
           <flow_mat>
             <material>
@@ -472,9 +470,9 @@ ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_CORRECT = '''\
             </material>
           </flow_mat>
         </itemfeedback>
-'''
+"""
 
-ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_INCORRECT = '''\
+ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_INCORRECT = """\
         <itemfeedback ident="general_incorrect_fb">
           <flow_mat>
             <material>
@@ -482,9 +480,9 @@ ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_INCORRECT = '''\
             </material>
           </flow_mat>
         </itemfeedback>
-'''
+"""
 
-ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_INDIVIDUAL = '''\
+ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_INDIVIDUAL = """\
         <itemfeedback ident="{ident}_fb">
           <flow_mat>
             <material>
@@ -492,30 +490,35 @@ ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_INDIVIDUAL = '''\
             </material>
           </flow_mat>
         </itemfeedback>
-'''
-
-
+"""
 
 
 def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str:
-    '''
+    """
     Generate assessment XML from Quiz.
-    '''
+    """
     xml = []
-    xml.append(BEFORE_ITEMS.format(assessment_identifier=assessment_identifier,
-                                   title=title_xml))
+    xml.append(BEFORE_ITEMS.format(assessment_identifier=assessment_identifier, title=title_xml))
     for question_or_delim in quiz.questions_and_delims:
         if isinstance(question_or_delim, TextRegion):
-            xml.append(TEXT.format(ident=f'text2qti_text_{question_or_delim.id}',
-                                   text_title_xml=question_or_delim.title_xml,
-                                   assessment_question_identifierref=f'text2qti_question_ref_{question_or_delim.id}',
-                                   text_html_xml=question_or_delim.text_html_xml))
+            xml.append(
+                TEXT.format(
+                    ident=f"text2qti_text_{question_or_delim.id}",
+                    text_title_xml=question_or_delim.title_xml,
+                    assessment_question_identifierref=f"text2qti_question_ref_{question_or_delim.id}",
+                    text_html_xml=question_or_delim.text_html_xml,
+                )
+            )
             continue
         if isinstance(question_or_delim, GroupStart):
-            xml.append(GROUP_START.format(ident=f'text2qti_group_{question_or_delim.group.id}',
-                                          group_title=question_or_delim.group.title_xml,
-                                          pick=question_or_delim.group.pick,
-                                          points_per_item=question_or_delim.group.points_per_question))
+            xml.append(
+                GROUP_START.format(
+                    ident=f"text2qti_group_{question_or_delim.group.id}",
+                    group_title=question_or_delim.group.title_xml,
+                    pick=question_or_delim.group.pick,
+                    points_per_item=question_or_delim.group.points_per_question,
+                )
+            )
             continue
         if isinstance(question_or_delim, GroupEnd):
             xml.append(GROUP_END)
@@ -524,54 +527,64 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
             raise TypeError
         question = question_or_delim
 
-        xml.append(START_ITEM.format(question_identifier=f'text2qti_question_{question.id}',
-                                     question_title=question.title_xml))
+        xml.append(
+            START_ITEM.format(question_identifier=f"text2qti_question_{question.id}", question_title=question.title_xml)
+        )
 
-        if question.type in ('true_false_question', 'multiple_choice_question',
-                             'short_answer_question', 'multiple_answers_question',
-                             ):
+        if question.type in (
+            "true_false_question",
+            "multiple_choice_question",
+            "short_answer_question",
+            "multiple_answers_question",
+        ):
             item_metadata = ITEM_METADATA_MCTF_SHORTANS_MULTANS_NUM
-            original_answer_ids = ','.join(f'text2qti_choice_{c.id}' for c in question.choices)
-        elif question.type == 'numerical_question':
+            original_answer_ids = ",".join(f"text2qti_choice_{c.id}" for c in question.choices)
+        elif question.type == "numerical_question":
             item_metadata = ITEM_METADATA_MCTF_SHORTANS_MULTANS_NUM
-            original_answer_ids = f'text2qti_numerical_{question.id}'
-        elif question.type == 'essay_question':
+            original_answer_ids = f"text2qti_numerical_{question.id}"
+        elif question.type == "essay_question":
             item_metadata = ITEM_METADATA_ESSAY
-            original_answer_ids = f'text2qti_essay_{question.id}'
-        elif question.type == 'file_upload_question':
+            original_answer_ids = f"text2qti_essay_{question.id}"
+        elif question.type == "file_upload_question":
             item_metadata = ITEM_METADATA_UPLOAD
-            original_answer_ids = f'text2qti_upload_{question.id}'
-        elif question.type == 'matching_question':
+            original_answer_ids = f"text2qti_upload_{question.id}"
+        elif question.type == "matching_question":
             item_metadata = ITEM_METADATA_MATCHING
-            original_answer_ids = ','.join(f'text2qti_choice_{c.id}' for c in question.choices)
+            original_answer_ids = ",".join(f"text2qti_choice_{c.id}" for c in question.choices)
         else:
             raise ValueError
-        xml.append(item_metadata.format(question_type=question.type,
-                                        points_possible=question.points_possible,
-                                        original_answer_ids=original_answer_ids,
-                                        assessment_question_identifierref=f'text2qti_question_ref_{question.id}'))
+        xml.append(
+            item_metadata.format(
+                question_type=question.type,
+                points_possible=question.points_possible,
+                original_answer_ids=original_answer_ids,
+                assessment_question_identifierref=f"text2qti_question_ref_{question.id}",
+            )
+        )
 
-        if question.type in ('true_false_question', 'multiple_choice_question', 'multiple_answers_question'):
-            if question.type in ('true_false_question', 'multiple_choice_question'):
+        if question.type in ("true_false_question", "multiple_choice_question", "multiple_answers_question"):
+            if question.type in ("true_false_question", "multiple_choice_question"):
                 item_presentation_choice = ITEM_PRESENTATION_MCTF_CHOICE
                 item_presentation = ITEM_PRESENTATION_MCTF
-            elif question.type == 'multiple_answers_question':
+            elif question.type == "multiple_answers_question":
                 item_presentation_choice = ITEM_PRESENTATION_MULTANS_CHOICE
                 item_presentation = ITEM_PRESENTATION_MULTANS
             else:
                 raise ValueError
-            choices = '\n'.join(item_presentation_choice.format(ident=f'text2qti_choice_{c.id}', choice_html_xml=c.choice_html_xml)
-                                                                for c in question.choices)
+            choices = "\n".join(
+                item_presentation_choice.format(ident=f"text2qti_choice_{c.id}", choice_html_xml=c.choice_html_xml)
+                for c in question.choices
+            )
             xml.append(item_presentation.format(question_html_xml=question.question_html_xml, choices=choices))
-        elif question.type == 'short_answer_question':
+        elif question.type == "short_answer_question":
             xml.append(ITEM_PRESENTATION_SHORTANS.format(question_html_xml=question.question_html_xml))
-        elif question.type == 'numerical_question':
+        elif question.type == "numerical_question":
             xml.append(ITEM_PRESENTATION_NUM.format(question_html_xml=question.question_html_xml))
-        elif question.type == 'essay_question':
+        elif question.type == "essay_question":
             xml.append(ITEM_PRESENTATION_ESSAY.format(question_html_xml=question.question_html_xml))
-        elif question.type == 'file_upload_question':
+        elif question.type == "file_upload_question":
             xml.append(ITEM_PRESENTATION_UPLOAD.format(question_html_xml=question.question_html_xml))
-        elif question.type == 'matching_question':
+        elif question.type == "matching_question":
             render_choices_list = []
             for c in question.choices:
                 matching_pattern = r"(.*)\s->\s(.*)"
@@ -581,7 +594,11 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
                     answer_str = match.group(2)
                 else:
                     raise ValueError("Matching question not formatted correctly")
-                render_choices_list.append(ITEM_PRESENTATION_MATCHING_RENDER_CHOICE.format(ident=f'text2qti_choice_{c.id}', answer=answer_str, choice_html_xml=question_str))
+                render_choices_list.append(
+                    ITEM_PRESENTATION_MATCHING_RENDER_CHOICE.format(
+                        ident=f"text2qti_choice_{c.id}", answer=answer_str, choice_html_xml=question_str
+                    )
+                )
 
             render_choices = "\n".join(render_choices_list)
             choices_list = []
@@ -593,19 +610,23 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
                     answer_str = match.group(2)
                 else:
                     raise ValueError("Matching question not formatted correctly")
-                choices_list.append(ITEM_PRESENTATION_MATCHING_CHOICE.format(ident=f'text2qti_choice_{c.id}', render_choices=render_choices, choice_html_xml=question_str))
+                choices_list.append(
+                    ITEM_PRESENTATION_MATCHING_CHOICE.format(
+                        ident=f"text2qti_choice_{c.id}", render_choices=render_choices, choice_html_xml=question_str
+                    )
+                )
 
             choices = "\n".join(choices_list)
             xml.append(ITEM_PRESENTATION_MATCHING.format(question_html_xml=question.question_html_xml, choices=choices))
         else:
             raise ValueError
 
-        if question.type in ('true_false_question', 'multiple_choice_question'):
+        if question.type in ("true_false_question", "multiple_choice_question"):
             correct_choice = None
             for choice in question.choices:
                 if choice.correct:
-                  correct_choice = choice
-                  break
+                    correct_choice = choice
+                    break
             if correct_choice is None:
                 raise TypeError
             resprocessing = []
@@ -614,60 +635,90 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
                 resprocessing.append(ITEM_RESPROCESSING_MCTF_GENERAL_FEEDBACK)
             for choice in question.choices:
                 if choice.feedback_raw is not None:
-                    resprocessing.append(ITEM_RESPROCESSING_MCTF_CHOICE_FEEDBACK.format(ident=f'text2qti_choice_{choice.id}'))
+                    resprocessing.append(
+                        ITEM_RESPROCESSING_MCTF_CHOICE_FEEDBACK.format(ident=f"text2qti_choice_{choice.id}")
+                    )
             if question.correct_feedback_raw is not None:
-                resprocessing.append(ITEM_RESPROCESSING_MCTF_SET_CORRECT_WITH_FEEDBACK.format(ident=f'text2qti_choice_{correct_choice.id}'))
+                resprocessing.append(
+                    ITEM_RESPROCESSING_MCTF_SET_CORRECT_WITH_FEEDBACK.format(
+                        ident=f"text2qti_choice_{correct_choice.id}"
+                    )
+                )
             else:
-                resprocessing.append(ITEM_RESPROCESSING_MCTF_SET_CORRECT_NO_FEEDBACK.format(ident=f'text2qti_choice_{correct_choice.id}'))
+                resprocessing.append(
+                    ITEM_RESPROCESSING_MCTF_SET_CORRECT_NO_FEEDBACK.format(ident=f"text2qti_choice_{correct_choice.id}")
+                )
             if question.incorrect_feedback_raw is not None:
                 resprocessing.append(ITEM_RESPROCESSING_MCTF_INCORRECT_FEEDBACK)
             resprocessing.append(ITEM_RESPROCESSING_END)
             xml.extend(resprocessing)
-        elif question.type == 'short_answer_question':
+        elif question.type == "short_answer_question":
             resprocessing = []
             resprocessing.append(ITEM_RESPROCESSING_START)
             if question.feedback_raw is not None:
                 resprocessing.append(ITEM_RESPROCESSING_SHORTANS_GENERAL_FEEDBACK)
             for choice in question.choices:
                 if choice.feedback_raw is not None:
-                    resprocessing.append(ITEM_RESPROCESSING_SHORTANS_CHOICE_FEEDBACK.format(ident=f'text2qti_choice_{choice.id}', answer_xml=choice.choice_xml))
+                    resprocessing.append(
+                        ITEM_RESPROCESSING_SHORTANS_CHOICE_FEEDBACK.format(
+                            ident=f"text2qti_choice_{choice.id}", answer_xml=choice.choice_xml
+                        )
+                    )
             varequal = []
             for choice in question.choices:
                 varequal.append(ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_VAREQUAL.format(answer_xml=choice.choice_xml))
             if question.correct_feedback_raw is not None:
-                resprocessing.append(ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_WITH_FEEDBACK.format(varequal='\n'.join(varequal)))
+                resprocessing.append(
+                    ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_WITH_FEEDBACK.format(varequal="\n".join(varequal))
+                )
             else:
-                resprocessing.append(ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_NO_FEEDBACK.format(varequal='\n'.join(varequal)))
+                resprocessing.append(
+                    ITEM_RESPROCESSING_SHORTANS_SET_CORRECT_NO_FEEDBACK.format(varequal="\n".join(varequal))
+                )
             if question.incorrect_feedback_raw is not None:
                 resprocessing.append(ITEM_RESPROCESSING_SHORTANS_INCORRECT_FEEDBACK)
             resprocessing.append(ITEM_RESPROCESSING_END)
             xml.extend(resprocessing)
-        elif question.type == 'multiple_answers_question':
+        elif question.type == "multiple_answers_question":
             resprocessing = []
             resprocessing.append(ITEM_RESPROCESSING_START)
             if question.feedback_raw is not None:
                 resprocessing.append(ITEM_RESPROCESSING_MULTANS_GENERAL_FEEDBACK)
             for choice in question.choices:
                 if choice.feedback_raw is not None:
-                    resprocessing.append(ITEM_RESPROCESSING_MULTANS_CHOICE_FEEDBACK.format(ident=f'text2qti_choice_{choice.id}'))
+                    resprocessing.append(
+                        ITEM_RESPROCESSING_MULTANS_CHOICE_FEEDBACK.format(ident=f"text2qti_choice_{choice.id}")
+                    )
             varequal = []
             for choice in question.choices:
                 if choice.correct:
-                    varequal.append(ITEM_RESPROCESSING_MULTANS_SET_CORRECT_VAREQUAL_CORRECT.format(ident=f'text2qti_choice_{choice.id}'))
+                    varequal.append(
+                        ITEM_RESPROCESSING_MULTANS_SET_CORRECT_VAREQUAL_CORRECT.format(
+                            ident=f"text2qti_choice_{choice.id}"
+                        )
+                    )
                 else:
-                    varequal.append(ITEM_RESPROCESSING_MULTANS_SET_CORRECT_VAREQUAL_INCORRECT.format(ident=f'text2qti_choice_{choice.id}'))
+                    varequal.append(
+                        ITEM_RESPROCESSING_MULTANS_SET_CORRECT_VAREQUAL_INCORRECT.format(
+                            ident=f"text2qti_choice_{choice.id}"
+                        )
+                    )
             if question.correct_feedback_raw is not None:
-                resprocessing.append(ITEM_RESPROCESSING_MULTANS_SET_CORRECT_WITH_FEEDBACK.format(varequal='\n'.join(varequal)))
+                resprocessing.append(
+                    ITEM_RESPROCESSING_MULTANS_SET_CORRECT_WITH_FEEDBACK.format(varequal="\n".join(varequal))
+                )
             else:
-                resprocessing.append(ITEM_RESPROCESSING_MULTANS_SET_CORRECT_NO_FEEDBACK.format(varequal='\n'.join(varequal)))
+                resprocessing.append(
+                    ITEM_RESPROCESSING_MULTANS_SET_CORRECT_NO_FEEDBACK.format(varequal="\n".join(varequal))
+                )
             if question.incorrect_feedback_raw is not None:
                 resprocessing.append(ITEM_RESPROCESSING_MULTANS_INCORRECT_FEEDBACK)
             resprocessing.append(ITEM_RESPROCESSING_END)
             xml.extend(resprocessing)
-        elif question.type == 'numerical_question':
+        elif question.type == "numerical_question":
             xml.append(ITEM_RESPROCESSING_START)
             if question.feedback_raw is not None:
-              xml.append(ITEM_RESPROCESSING_NUM_GENERAL_FEEDBACK)
+                xml.append(ITEM_RESPROCESSING_NUM_GENERAL_FEEDBACK)
             if question.correct_feedback_raw is None:
                 if question.numerical_exact is None:
                     item_resprocessing_num_set_correct = ITEM_RESPROCESSING_NUM_RANGE_SET_CORRECT_NO_FEEDBACK
@@ -678,28 +729,32 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
                     item_resprocessing_num_set_correct = ITEM_RESPROCESSING_NUM_RANGE_SET_CORRECT_WITH_FEEDBACK
                 else:
                     item_resprocessing_num_set_correct = ITEM_RESPROCESSING_NUM_EXACT_SET_CORRECT_WITH_FEEDBACK
-            xml.append(item_resprocessing_num_set_correct.format(num_min=question.numerical_min_html_xml,
-                                                                 num_exact=question.numerical_exact_html_xml,
-                                                                 num_max=question.numerical_max_html_xml))
+            xml.append(
+                item_resprocessing_num_set_correct.format(
+                    num_min=question.numerical_min_html_xml,
+                    num_exact=question.numerical_exact_html_xml,
+                    num_max=question.numerical_max_html_xml,
+                )
+            )
             if question.incorrect_feedback_raw is not None:
                 xml.append(ITEM_RESPROCESSING_NUM_INCORRECT_FEEDBACK)
             xml.append(ITEM_RESPROCESSING_END)
-        elif question.type == 'essay_question':
+        elif question.type == "essay_question":
             xml.append(ITEM_RESPROCESSING_START)
             xml.append(ITEM_RESPROCESSING_ESSAY)
             if question.feedback_raw is not None:
                 xml.append(ITEM_RESPROCESSING_ESSAY_GENERAL_FEEDBACK)
             xml.append(ITEM_RESPROCESSING_END)
-        elif question.type == 'file_upload_question':
+        elif question.type == "file_upload_question":
             xml.append(ITEM_RESPROCESSING_START)
             if question.feedback_raw is not None:
                 xml.append(ITEM_RESPROCESSING_UPLOAD_GENERAL_FEEDBACK)
             xml.append(ITEM_RESPROCESSING_END)
-        elif question.type == 'matching_question':
+        elif question.type == "matching_question":
             resprocessing = []
             resprocessing.append(ITEM_RESPROCESSING_START)
-             # TODO: Later.
-            #if question.feedback_raw is not None:
+            # TODO: Later.
+            # if question.feedback_raw is not None:
             #    resprocessing.append(ITEM_RESPROCESSING_MULTANS_GENERAL_FEEDBACK)
 
             # for choice in question.choices:
@@ -708,11 +763,15 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
 
             varequal = []
             for choice in question.choices:
-                  varequal.append(ITEM_RESPROCESSING_MATCHING.format(ident=f'text2qti_choice_{choice.id}'))
+                varequal.append(ITEM_RESPROCESSING_MATCHING.format(ident=f"text2qti_choice_{choice.id}"))
             if question.correct_feedback_raw is not None:
-               resprocessing.append(ITEM_RESPROCESSING_MULTANS_SET_CORRECT_WITH_FEEDBACK.format(varequal='\n'.join(varequal)))
+                resprocessing.append(
+                    ITEM_RESPROCESSING_MULTANS_SET_CORRECT_WITH_FEEDBACK.format(varequal="\n".join(varequal))
+                )
             else:
-                resprocessing.append(ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK.format(varequal='\n'.join(varequal)))
+                resprocessing.append(
+                    ITEM_RESPROCESSING_MATCHING_SET_CORRECT_NO_FEEDBACK.format(varequal="\n".join(varequal))
+                )
             # if question.incorrect_feedback_raw is not None:
             #     resprocessing.append(ITEM_RESPROCESSING_MULTANS_INCORRECT_FEEDBACK)
             resprocessing.append(ITEM_RESPROCESSING_END)
@@ -720,24 +779,43 @@ def assessment(*, quiz: Quiz, assessment_identifier: str, title_xml: str) -> str
         else:
             raise ValueError
 
-        if question.type in ('true_false_question', 'multiple_choice_question',
-                             'short_answer_question', 'multiple_answers_question',
-                             'numerical_question', 'essay_question', 'file_upload_question'):
+        if question.type in (
+            "true_false_question",
+            "multiple_choice_question",
+            "short_answer_question",
+            "multiple_answers_question",
+            "numerical_question",
+            "essay_question",
+            "file_upload_question",
+        ):
             if question.feedback_raw is not None:
                 xml.append(ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_GENERAL.format(feedback=question.feedback_html_xml))
             if question.correct_feedback_raw is not None:
-                xml.append(ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_CORRECT.format(feedback=question.correct_feedback_html_xml))
+                xml.append(
+                    ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_CORRECT.format(feedback=question.correct_feedback_html_xml)
+                )
             if question.incorrect_feedback_raw is not None:
-                xml.append(ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_INCORRECT.format(feedback=question.incorrect_feedback_html_xml))
-        if question.type in ('true_false_question', 'multiple_choice_question',
-                             'short_answer_question', 'multiple_answers_question'):
+                xml.append(
+                    ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_INCORRECT.format(
+                        feedback=question.incorrect_feedback_html_xml
+                    )
+                )
+        if question.type in (
+            "true_false_question",
+            "multiple_choice_question",
+            "short_answer_question",
+            "multiple_answers_question",
+        ):
             for choice in question.choices:
                 if choice.feedback_raw is not None:
-                    xml.append(ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_INDIVIDUAL.format(ident=f'text2qti_choice_{choice.id}',
-                                                                                         feedback=choice.feedback_html_xml))
+                    xml.append(
+                        ITEM_FEEDBACK_MCTF_SHORTANS_MULTANS_NUM_INDIVIDUAL.format(
+                            ident=f"text2qti_choice_{choice.id}", feedback=choice.feedback_html_xml
+                        )
+                    )
 
         xml.append(END_ITEM)
 
     xml.append(AFTER_ITEMS)
 
-    return ''.join(xml)
+    return "".join(xml)

--- a/text2qti/xml_assessment_meta.py
+++ b/text2qti/xml_assessment_meta.py
@@ -28,7 +28,7 @@ TEMPLATE = """\
   <show_correct_answers>{show_correct_answers}</show_correct_answers>
   <anonymous_submissions>false</anonymous_submissions>
   <could_be_locked>false</could_be_locked>
-  <allowed_attempts>1</allowed_attempts>
+  <allowed_attempts>{allowed_attempts}</allowed_attempts>
   <one_question_at_a_time>{one_question_at_a_time}</one_question_at_a_time>
   <cant_go_back>{cant_go_back}</cant_go_back>
   <available>false</available>
@@ -96,6 +96,7 @@ def assessment_meta(
     show_correct_answers: str,
     one_question_at_a_time: str,
     cant_go_back: str,
+    allowed_attempts: str,
 ) -> str:
     """
     Generate `assessment_meta.xml`.
@@ -113,4 +114,5 @@ def assessment_meta(
         hide_results="always" if show_correct_answers == "false" else "",
         one_question_at_a_time=one_question_at_a_time,
         cant_go_back=cant_go_back,
+        allowed_attempts=allowed_attempts,
     )

--- a/text2qti/xml_assessment_meta.py
+++ b/text2qti/xml_assessment_meta.py
@@ -10,12 +10,12 @@
 
 from typing import Union
 
-
-TEMPLATE = '''\
+TEMPLATE = """\
 <?xml version="1.0" encoding="UTF-8"?>
 <quiz identifier="{assessment_identifier}" xmlns="http://canvas.instructure.com/xsd/cccv1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://canvas.instructure.com/xsd/cccv1p0 https://canvas.instructure.com/xsd/cccv1p0.xsd">
   <title>{title}</title>
   <description>{description}</description>
+  <shuffle_questions>{shuffle_questions}</shuffle_questions>
   <shuffle_answers>{shuffle_answers}</shuffle_answers>
   <scoring_policy>keep_highest</scoring_policy>
   <hide_results>{hide_results}</hide_results>
@@ -80,31 +80,37 @@ TEMPLATE = '''\
   <assignment_overrides>
   </assignment_overrides>
 </quiz>
-'''
+"""
 
 
-def assessment_meta(*,
-                    assessment_identifier: str,
-                    assignment_group_identifier: str,
-                    assignment_identifier: str,
-                    title_xml: str,
-                    description_html_xml: str,
-                    points_possible: Union[int, float],
-                    shuffle_answers: str,
-                    show_correct_answers: str,
-                    one_question_at_a_time: str,
-                    cant_go_back: str) -> str:
-    '''
+def assessment_meta(
+    *,
+    assessment_identifier: str,
+    assignment_group_identifier: str,
+    assignment_identifier: str,
+    title_xml: str,
+    description_html_xml: str,
+    points_possible: Union[int, float],
+    shuffle_answers: str,
+    shuffle_questions: str,
+    show_correct_answers: str,
+    one_question_at_a_time: str,
+    cant_go_back: str,
+) -> str:
+    """
     Generate `assessment_meta.xml`.
-    '''
-    return TEMPLATE.format(assessment_identifier=assessment_identifier,
-                           assignment_identifier=assignment_identifier,
-                           assignment_group_identifier=assignment_group_identifier,
-                           title=title_xml,
-                           description=description_html_xml,
-                           points_possible=points_possible,
-                           shuffle_answers=shuffle_answers,
-                           show_correct_answers=show_correct_answers,
-                           hide_results='always' if show_correct_answers == 'false' else '',
-                           one_question_at_a_time=one_question_at_a_time,
-                           cant_go_back=cant_go_back)
+    """
+    return TEMPLATE.format(
+        assessment_identifier=assessment_identifier,
+        assignment_identifier=assignment_identifier,
+        assignment_group_identifier=assignment_group_identifier,
+        title=title_xml,
+        description=description_html_xml,
+        points_possible=points_possible,
+        shuffle_answers=shuffle_answers,
+        shuffle_questions=shuffle_questions,
+        show_correct_answers=show_correct_answers,
+        hide_results="always" if show_correct_answers == "false" else "",
+        one_question_at_a_time=one_question_at_a_time,
+        cant_go_back=cant_go_back,
+    )


### PR DESCRIPTION
Hey!
Will start off by saying thanking you for this great tool, really helpful for us who don't enjoy clicking through the Canvas UI.

I have gone ahead and added two new question types:

- Matching question. (Closes #54) 
Syntax example:
```
> "question1" -> "choice1"
> "question2" -> "choice2"
> _ -> "distractor1"
> _ -> "distractor2"
```

- Ordering question
Syntax example:
```
~ "Alternative 1"
~ "Alternative 2"
~ "Alternative 3"
```
Both questions work as an old and a new quiz (by converting during upload to canvas).

Currently, I haven't added the possibility to add feedback to the new questions, since we have used it yet in our courses. But this is definitely something I could add.

Some other smaller changes:
- I fixed a bug which added the individual points from all questions within a group to the total available points of the quiz. 
- Made it possible to add True/False questions with the alternatives in Swedish (Sant/Falskt).

Happy to hear what you think and open to suggestions for changes. 